### PR TITLE
Add integrated FirebaseUI sign‑in

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -124,6 +124,7 @@ dependencies {
     implementation 'com.google.firebase:firebase-auth'
     implementation 'com.google.firebase:firebase-appcheck'
     implementation 'com.google.firebase:firebase-appcheck-playintegrity'
+    implementation 'com.firebaseui:firebase-ui-auth:8.0.0'
 
     // Network
     implementation 'com.squareup.okhttp3:okhttp:4.11.0'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -61,6 +61,11 @@
             </intent-filter>
         </activity>
 
+        <!-- FirebaseUI Sign-In Activity -->
+        <activity
+            android:name=".ui.SignInActivity"
+            android:exported="false" />
+
         <!-- Live Transcription Activity -->
         <activity
             android:name=".ui.LiveTranscriptionActivity"

--- a/app/src/main/java/com/mshomeguardian/logger/ui/MainActivity.kt
+++ b/app/src/main/java/com/mshomeguardian/logger/ui/MainActivity.kt
@@ -19,8 +19,11 @@ import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
+import com.firebase.ui.auth.AuthUI
 import com.mshomeguardian.logger.R
+import com.mshomeguardian.logger.ui.SignInActivity
 import com.mshomeguardian.logger.data.AppDatabase
+import com.mshomeguardian.logger.utils.AuthManager
 import com.mshomeguardian.logger.services.LocationMonitoringService
 import com.mshomeguardian.logger.utils.DataSyncManager
 import com.mshomeguardian.logger.utils.DeviceIdentifier
@@ -62,6 +65,7 @@ class MainActivity : AppCompatActivity() {
     private lateinit var syncButton: Button
     private lateinit var recordingButton: Button
     private lateinit var liveTranscriptionButton: Button  // New button for live transcription
+    private lateinit var signOutButton: Button
 
     // Status text views
     private lateinit var locationStatusText: TextView
@@ -108,6 +112,10 @@ class MainActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
 
+        if (!AuthManager.isSignedIn()) {
+            startSignInActivity()
+        }
+
         // Initialize UI elements
         statusText = findViewById(R.id.statusText)
         permissionsButton = findViewById(R.id.permissionsButton)
@@ -115,6 +123,7 @@ class MainActivity : AppCompatActivity() {
         syncButton = findViewById(R.id.syncButton)
         recordingButton = findViewById(R.id.recordingButton)
         liveTranscriptionButton = findViewById(R.id.liveTranscriptionButton)  // Initialize new button
+        signOutButton = findViewById(R.id.signOutButton)
 
         // Status text views
         locationStatusText = findViewById(R.id.locationStatusText)
@@ -177,6 +186,12 @@ class MainActivity : AppCompatActivity() {
                 )
             }
         }
+
+        signOutButton.setOnClickListener {
+            AuthUI.getInstance().signOut(this).addOnCompleteListener {
+                startSignInActivity()
+            }
+        }
         // Check permissions on startup
         updatePermissionStatus()
 
@@ -196,6 +211,11 @@ class MainActivity : AppCompatActivity() {
      */
     private fun startLiveTranscription() {
         val intent = Intent(this, LiveTranscriptionActivity::class.java)
+        startActivity(intent)
+    }
+
+    private fun startSignInActivity() {
+        val intent = Intent(this, SignInActivity::class.java)
         startActivity(intent)
     }
 

--- a/app/src/main/java/com/mshomeguardian/logger/ui/SignInActivity.kt
+++ b/app/src/main/java/com/mshomeguardian/logger/ui/SignInActivity.kt
@@ -1,0 +1,64 @@
+package com.mshomeguardian.logger.ui
+
+import android.app.Activity
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import com.firebase.ui.auth.AuthUI
+import com.firebase.ui.auth.FirebaseAuthUIActivityResultContract
+import com.firebase.ui.auth.data.model.FirebaseAuthUIAuthenticationResult
+import com.google.firebase.auth.ActionCodeSettings
+
+/**
+ * Activity that launches FirebaseUI sign-in flow with email/password,
+ * phone, and passwordless email link providers.
+ */
+class SignInActivity : AppCompatActivity() {
+
+    private val signInLauncher =
+        registerForActivityResult(FirebaseAuthUIActivityResultContract()) { res ->
+            onSignInResult(res)
+        }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        launchSignIn()
+    }
+
+    private fun launchSignIn() {
+        val actionCodeSettings = ActionCodeSettings.newBuilder()
+            .setAndroidPackageName(packageName, true, null)
+            .setHandleCodeInApp(true)
+            .setUrl("https://example.page.link")
+            .build()
+
+        val providers = arrayListOf(
+            // Passwordless email link
+            AuthUI.IdpConfig.EmailBuilder()
+                .enableEmailLinkSignIn()
+                .setActionCodeSettings(actionCodeSettings)
+                .build(),
+            // Phone authentication
+            AuthUI.IdpConfig.PhoneBuilder().build(),
+            // Regular email/password
+            AuthUI.IdpConfig.EmailBuilder().build()
+        )
+
+        val intent = AuthUI.getInstance()
+            .createSignInIntentBuilder()
+            .setAvailableProviders(providers)
+            .setIsSmartLockEnabled(false)
+            .build()
+
+        signInLauncher.launch(intent)
+    }
+
+    private fun onSignInResult(result: FirebaseAuthUIAuthenticationResult) {
+        if (result.resultCode == Activity.RESULT_OK) {
+            // User successfully signed in
+            finish()
+        } else {
+            // Sign in failed or cancelled
+            finish()
+        }
+    }
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -59,6 +59,13 @@
             android:enabled="false"
             android:layout_marginBottom="16dp" />
 
+        <Button
+            android:id="@+id/signOutButton"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/sign_out"
+            android:layout_marginBottom="16dp" />
+
         <!-- Data Collection Status Section -->
         <TextView
             android:id="@+id/dataStatusText"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -14,4 +14,5 @@
     <string name="stop_transcription">Stop Transcription</string>
     <string name="transcription_activity_title">Live Transcription</string>
     <string name="transcription_placeholder">Transcribed text will appear here...</string>
+    <string name="sign_out">Sign Out</string>
 </resources>


### PR DESCRIPTION
## Summary
- remove standalone SignInSample project
- integrate FirebaseUI sign-in providers into main app
- add `SignInActivity` and sign-out button
- wire sign-in flow from `MainActivity`
- include FirebaseUI dependency

## Testing
- `./gradlew test --no-daemon` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_68563eb5a7a08328877b642251b6e9e2