### PR TITLE
Fix WorkManager init on boot

### DIFF
--- a/app/src/main/java/com/mshomeguardian/logger/services/BootReceiver.kt
+++ b/app/src/main/java/com/mshomeguardian/logger/services/BootReceiver.kt
@@ -6,6 +6,7 @@ import android.content.Intent
 import android.os.Build
 import android.util.Log
 import com.mshomeguardian.logger.workers.WorkerScheduler
+import com.mshomeguardian.logger.utils.WorkManagerInitializer
 
 class BootReceiver : BroadcastReceiver() {
     companion object {
@@ -15,6 +16,9 @@ class BootReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context?, intent: Intent?) {
         if (intent?.action == Intent.ACTION_BOOT_COMPLETED && context != null) {
             Log.d(TAG, "Device booted. Starting services...")
+
+            // Initialize WorkManager before scheduling any jobs
+            WorkManagerInitializer.initialize(context)
 
             // Schedule all worker jobs
             WorkerScheduler.schedule(context)


### PR DESCRIPTION
## Summary
- initialize WorkManager in `BootReceiver` before scheduling workers

## Testing
- `./gradlew test --console=plain` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_684d87b8120c8328bfd1fc3e1332b115