### PR TITLE
Fix Firebase AppCheck crash

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -124,6 +124,8 @@ dependencies {
     implementation 'com.google.firebase:firebase-auth'
     implementation 'com.google.firebase:firebase-appcheck'
     implementation 'com.google.firebase:firebase-appcheck-playintegrity'
+    // Needed for Firestore to integrate with App Check
+    implementation 'com.google.firebase:firebase-appcheck-interop'
     implementation 'com.firebaseui:firebase-ui-auth:8.0.0'
 
     // Network

--- a/build.gradle
+++ b/build.gradle
@@ -46,11 +46,6 @@ subprojects {
             force 'androidx.core:core-ktx:1.12.0'
             force 'androidx.appcompat:appcompat:1.6.1'
 
-            // Force compatible Firebase versions to avoid Kotlin version conflicts
-            force 'com.google.firebase:firebase-common:20.4.2'
-            force 'com.google.firebase:firebase-firestore:24.4.1'
-            force 'com.google.firebase:firebase-auth:22.3.0'
-            force 'com.google.firebase:firebase-storage:20.3.0'
         }
     }
 }


### PR DESCRIPTION
## Summary
- remove forced Firebase versions in root build file
- add `firebase-appcheck-interop` to app dependencies

## Testing
- `./gradlew tasks` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_68567906f4c08328b62b1777d327e104