### PR TITLE
Fix Firebase AppCheck crash

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -117,13 +117,16 @@ dependencies {
     implementation "androidx.lifecycle:lifecycle-service:$lifecycle_version"
 
     // Firebase - NO KTX to avoid conflicts
-    implementation platform('com.google.firebase:firebase-bom:32.7.0')
+    // Use the latest Firebase BoM for consistent versions
+    implementation platform('com.google.firebase:firebase-bom:33.0.0')
     implementation 'com.google.firebase:firebase-analytics'
     implementation 'com.google.firebase:firebase-firestore'
     implementation 'com.google.firebase:firebase-storage'
     implementation 'com.google.firebase:firebase-auth'
     implementation 'com.google.firebase:firebase-appcheck'
     implementation 'com.google.firebase:firebase-appcheck-playintegrity'
+    // Include AppCheck interop so Firestore can locate its token provider
+    implementation 'com.google.firebase:firebase-appcheck-interop:17.0.0'
     implementation 'com.firebaseui:firebase-ui-auth:8.0.0'
 
     // Network

--- a/build.gradle
+++ b/build.gradle
@@ -46,11 +46,6 @@ subprojects {
             force 'androidx.core:core-ktx:1.12.0'
             force 'androidx.appcompat:appcompat:1.6.1'
 
-            // Force compatible Firebase versions to avoid Kotlin version conflicts
-            force 'com.google.firebase:firebase-common:20.4.2'
-            force 'com.google.firebase:firebase-firestore:24.4.1'
-            force 'com.google.firebase:firebase-auth:22.3.0'
-            force 'com.google.firebase:firebase-storage:20.3.0'
         }
     }
 }


### PR DESCRIPTION
## Summary
- update Firebase BOM
- depend on firebase-appcheck-interop using an explicit version

## Testing
- `./gradlew tasks` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_68567906f4c08328b62b1777d327e104