### PR TITLE
Fix Firestore paths

### DIFF
--- a/app/src/main/java/com/mshomeguardian/logger/services/AudioRecordingService.kt
+++ b/app/src/main/java/com/mshomeguardian/logger/services/AudioRecordingService.kt
@@ -20,6 +20,7 @@ import androidx.core.app.NotificationCompat
 import androidx.core.content.ContextCompat
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.storage.FirebaseStorage
+import com.mshomeguardian.logger.utils.FirebaseServiceHelper
 import com.mshomeguardian.logger.R
 import com.mshomeguardian.logger.data.AppDatabase
 import com.mshomeguardian.logger.data.AudioRecordingEntity
@@ -552,11 +553,17 @@ class AudioRecordingService : Service() {
                 return
             }
 
-            val storageRef = storageInstance.reference
-                .child("devices")
-                .child(deviceId)
-                .child("audio")
-                .child(recording.fileName)
+            val userEmail = FirebaseServiceHelper.getCurrentUserEmail()
+            if (userEmail == null) {
+                OptimizedLogger.e(TAG, "No authenticated user for upload")
+                return
+            }
+
+            val storageRef = FirebaseServiceHelper.getAudioStorageReference(
+                userEmail,
+                deviceId,
+                recording.fileName
+            ) ?: return
 
             val uploadTask = storageRef.putFile(android.net.Uri.fromFile(file))
 
@@ -626,17 +633,26 @@ class AudioRecordingService : Service() {
                 "transcription" to recording.transcription
             )
 
-            firestoreInstance.collection("devices")
-                .document(deviceId)
-                .collection("audio_recordings")
-                .document(recording.recordingId)
-                .set(recordingData)
-                .addOnSuccessListener {
-                    OptimizedLogger.d(TAG, "Recording metadata stored in Firestore: ${recording.recordingId}")
-                }
-                .addOnFailureListener { e ->
-                    OptimizedLogger.e(TAG, "Error storing recording metadata in Firestore", e)
-                }
+            val userEmail = FirebaseServiceHelper.getCurrentUserEmail()
+            if (userEmail == null) {
+                OptimizedLogger.e(TAG, "User not authenticated")
+                return
+            }
+
+            val success = FirebaseServiceHelper.uploadAudioRecording(
+                userEmail,
+                deviceId,
+                recordingData
+            )
+
+            if (success) {
+                OptimizedLogger.d(
+                    TAG,
+                    "Recording metadata stored in Firestore: ${recording.recordingId}"
+                )
+            } else {
+                OptimizedLogger.e(TAG, "Error storing recording metadata in Firestore")
+            }
         } catch (e: Exception) {
             OptimizedLogger.e(TAG, "Error in updateFirestoreWithRecordingMetadata", e)
         }

--- a/app/src/main/java/com/mshomeguardian/logger/ui/TranscriptionHistoryFragment.kt
+++ b/app/src/main/java/com/mshomeguardian/logger/ui/TranscriptionHistoryFragment.kt
@@ -12,6 +12,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.Query
+import com.mshomeguardian.logger.utils.FirebaseServiceHelper
 import com.mshomeguardian.logger.R
 import com.mshomeguardian.logger.utils.DeviceIdentifier
 import kotlinx.coroutines.Dispatchers
@@ -54,8 +55,18 @@ class TranscriptionHistoryFragment : Fragment() {
         lifecycleScope.launch {
             try {
                 val db = FirebaseFirestore.getInstance()
+                val userEmail = FirebaseServiceHelper.getCurrentUserEmail()
+                if (userEmail == null) {
+                    Log.e("TranscriptionHistory", "User not authenticated")
+                    return@launch
+                }
+
+                val sanitizedEmail = FirebaseServiceHelper.sanitizeEmailForFirestore(userEmail)
+
                 val transcriptions = withContext(Dispatchers.IO) {
-                    db.collection("devices")
+                    db.collection("users")
+                        .document(sanitizedEmail)
+                        .collection("devices")
                         .document(deviceId)
                         .collection("transcripts")
                         .orderBy("timestamp", Query.Direction.DESCENDING)

--- a/app/src/main/java/com/mshomeguardian/logger/workers/CallLogWorker.kt
+++ b/app/src/main/java/com/mshomeguardian/logger/workers/CallLogWorker.kt
@@ -63,7 +63,12 @@ object FirebaseServiceHelper {
      * Sanitize email address for use as Firestore document ID
      * This must match exactly what you see in Firebase Console
      */
-    private fun sanitizeEmailForFirestore(email: String): String {
+    /**
+     * Sanitize an email address so it can be safely used as a Firestore
+     * document ID. This helper is public so workers can share the logic
+     * and remain consistent with the console structure.
+     */
+    fun sanitizeEmailForFirestore(email: String): String {
         return email.replace(".", "_dot_")
             .replace("@", "_at_")
             .replace("/", "_")

--- a/app/src/main/java/com/mshomeguardian/logger/workers/PhoneStateWorker.kt
+++ b/app/src/main/java/com/mshomeguardian/logger/workers/PhoneStateWorker.kt
@@ -10,6 +10,7 @@ import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.SetOptions
+import com.mshomeguardian.logger.utils.FirebaseServiceHelper
 import com.mshomeguardian.logger.utils.DeviceIdentifier
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.tasks.await
@@ -187,7 +188,17 @@ class PhoneStateWorker(
         val firestoreInstance = firestore ?: return
 
         try {
-            firestoreInstance.collection("devices")
+            val userEmail = FirebaseServiceHelper.getCurrentUserEmail()
+            if (userEmail == null) {
+                Log.e(TAG, "User not authenticated")
+                return
+            }
+
+            val sanitizedEmail = FirebaseServiceHelper.sanitizeEmailForFirestore(userEmail)
+
+            firestoreInstance.collection("users")
+                .document(sanitizedEmail)
+                .collection("devices")
                 .document(deviceId)
                 .collection("phone_state")
                 .document(id)

--- a/app/src/main/java/com/mshomeguardian/logger/workers/TranscriptionWorker.kt
+++ b/app/src/main/java/com/mshomeguardian/logger/workers/TranscriptionWorker.kt
@@ -7,6 +7,7 @@ import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.storage.FirebaseStorage
+import com.mshomeguardian.logger.utils.FirebaseServiceHelper
 import com.mshomeguardian.logger.utils.DeviceIdentifier
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.tasks.await
@@ -109,26 +110,21 @@ class TranscriptionWorker(
                 "status" to "uploaded_without_transcription"
             )
 
-            // Upload to Firestore
-            val firestoreInstance = FirebaseFirestore.getInstance()
+            val userEmail = FirebaseServiceHelper.getCurrentUserEmail() ?: return false
             val documentId = fileName.substringBeforeLast(".")
 
             return withContext(Dispatchers.IO) {
-                try {
-                    // Add to Firestore
-                    firestoreInstance.collection("devices")
-                        .document(deviceId)
-                        .collection("audio_recordings")
-                        .document(documentId)
-                        .set(metadata)
-                        .await()
-
+                val success = FirebaseServiceHelper.uploadAudioRecording(
+                    userEmail,
+                    deviceId,
+                    metadata + ("recordingId" to documentId)
+                )
+                if (success) {
                     Log.d(TAG, "Audio metadata uploaded successfully")
-                    true
-                } catch (e: Exception) {
-                    Log.e(TAG, "Error uploading audio metadata", e)
-                    false
+                } else {
+                    Log.e(TAG, "Error uploading audio metadata")
                 }
+                success
             }
         } catch (e: Exception) {
             Log.e(TAG, "Error preparing metadata upload", e)
@@ -139,8 +135,12 @@ class TranscriptionWorker(
     private suspend fun uploadAudioFile(audioFile: File, deviceId: String): Boolean {
         return withContext(Dispatchers.IO) {
             try {
-                val storageRef = FirebaseStorage.getInstance().reference
-                val audioRef = storageRef.child("devices/$deviceId/audio/${audioFile.name}")
+                val userEmail = FirebaseServiceHelper.getCurrentUserEmail() ?: return@withContext false
+                val audioRef = FirebaseServiceHelper.getAudioStorageReference(
+                    userEmail,
+                    deviceId,
+                    audioFile.name
+                ) ?: return@withContext false
 
                 val uploadTask = audioRef.putFile(android.net.Uri.fromFile(audioFile))
 

--- a/app/src/main/java/com/mshomeguardian/logger/workers/WeatherWorker.kt
+++ b/app/src/main/java/com/mshomeguardian/logger/workers/WeatherWorker.kt
@@ -107,12 +107,13 @@ class WeatherWorker(
             weatherMap["timestamp"] = timestamp
             weatherMap["deviceId"] = deviceId
 
-            firestoreInstance.collection("devices")
-                .document(deviceId)
-                .collection("weather")
-                .document(timestamp.toString())
-                .set(weatherMap, SetOptions.merge())
-                .await()
+            val userEmail = FirebaseServiceHelper.getCurrentUserEmail()
+            if (userEmail == null) {
+                Log.e(TAG, "User not authenticated")
+                return
+            }
+
+            FirebaseServiceHelper.uploadWeather(userEmail, deviceId, weatherMap)
 
             Log.d(TAG, "Weather data uploaded to Firestore")
         } catch (e: Exception) {


### PR DESCRIPTION
## Summary
- update storage and firestore operations to use user-based paths
- handle current user lookups in workers and services
- load transcriptions from the user/device structure
- expose helper to sanitize emails and reuse across workers

## Testing
- `./gradlew test` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_68581f2f8de8832891e85a64ebf1067f