### PR TITLE
Fix logs for Firestore paths

### DIFF
--- a/app/src/main/java/com/mshomeguardian/logger/services/UnifiedMonitoringService.kt
+++ b/app/src/main/java/com/mshomeguardian/logger/services/UnifiedMonitoringService.kt
@@ -244,7 +244,9 @@ class CallLogWorker(
                         "uploadedAt" to System.currentTimeMillis()
                     )
 
-                    // This will create: /users/{sanitized_email}/devices/{deviceId}/call_logs/{callId}
+                    val sanitizedEmail = FirebaseServiceHelper.sanitizeEmailForFirestore(userEmail)
+                    val firestorePath = "users/$sanitizedEmail/devices/$deviceId/call_logs"
+                    Log.d(TAG, "Uploading to $firestorePath")
                     val success = FirebaseServiceHelper.uploadCallLog(userEmail, deviceId, callLogData)
 
                     if (success) {

--- a/app/src/main/java/com/mshomeguardian/logger/workers/CallLogWorker.kt
+++ b/app/src/main/java/com/mshomeguardian/logger/workers/CallLogWorker.kt
@@ -336,6 +336,34 @@ object FirebaseServiceHelper {
     }
 
     /**
+     * Upload phone state data with user-based structure
+     */
+    suspend fun uploadPhoneState(
+        userEmail: String,
+        deviceId: String,
+        id: String,
+        phoneStateData: Map<String, Any>
+    ): Boolean {
+        return safeFirestoreOperation(
+            operation = {
+                val firestoreInstance = firestore ?: return@safeFirestoreOperation false
+
+                val collectionPath = getCollectionPath(userEmail, deviceId, "phone_state")
+
+                firestoreInstance.collection(collectionPath)
+                    .document(id)
+                    .set(phoneStateData, SetOptions.merge())
+                    .await()
+
+                Log.d(TAG, "Phone state uploaded successfully for $userEmail")
+                true
+            },
+            operationName = "Upload phone state",
+            defaultValue = false
+        )
+    }
+
+    /**
      * Update device last active timestamp
      */
     suspend fun updateDeviceLastActive(userEmail: String, deviceId: String): Boolean {

--- a/app/src/main/java/com/mshomeguardian/logger/workers/PhoneStateWorker.kt
+++ b/app/src/main/java/com/mshomeguardian/logger/workers/PhoneStateWorker.kt
@@ -194,18 +194,18 @@ class PhoneStateWorker(
                 return
             }
 
-            val sanitizedEmail = FirebaseServiceHelper.sanitizeEmailForFirestore(userEmail)
+            val success = FirebaseServiceHelper.uploadPhoneState(
+                userEmail,
+                deviceId,
+                id,
+                phoneStateMap
+            )
 
-            firestoreInstance.collection("users")
-                .document(sanitizedEmail)
-                .collection("devices")
-                .document(deviceId)
-                .collection("phone_state")
-                .document(id)
-                .set(phoneStateMap, SetOptions.merge())
-                .await()
-
-            Log.d(TAG, "Phone state uploaded to Firestore")
+            if (success) {
+                Log.d(TAG, "Phone state uploaded to Firestore")
+            } else {
+                Log.e(TAG, "Failed to upload phone state")
+            }
         } catch (e: Exception) {
             Log.e(TAG, "Failed to upload phone state", e)
         }

--- a/app/src/main/java/com/mshomeguardian/logger/workers/WeatherWorker.kt
+++ b/app/src/main/java/com/mshomeguardian/logger/workers/WeatherWorker.kt
@@ -7,15 +7,11 @@ import android.util.Log
 import androidx.core.content.ContextCompat
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
-import com.google.firebase.firestore.FirebaseFirestore
-import com.google.firebase.firestore.SetOptions
 import com.mshomeguardian.logger.utils.DeviceIdentifier
 import com.mshomeguardian.logger.utils.LocationUtils
 import com.mshomeguardian.logger.utils.WeatherUtil
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.tasks.await
 import kotlinx.coroutines.withContext
-import java.util.HashMap
 import com.mshomeguardian.logger.utils.FirebaseServiceHelper
 
 class WeatherWorker(
@@ -25,12 +21,6 @@ class WeatherWorker(
 
     private val deviceId = DeviceIdentifier.getPersistentDeviceId(context.applicationContext)
 
-    private val firestore: FirebaseFirestore? = try {
-        FirebaseFirestore.getInstance()
-    } catch (e: Exception) {
-        Log.e(TAG, "Failed to initialize Firestore", e)
-        null
-    }
 
     companion object {
         private const val TAG = "WeatherWorker"
@@ -91,10 +81,8 @@ class WeatherWorker(
         weatherData: WeatherUtil.WeatherData,
         timestamp: Long
     ) {
-        val firestoreInstance = firestore ?: return
-
         try {
-            val weatherMap = HashMap<String, Any>()
+            val weatherMap = mutableMapOf<String, Any>()
             weatherMap["latitude"] = latitude
             weatherMap["longitude"] = longitude
             weatherMap["temperature"] = weatherData.temperature
@@ -113,9 +101,16 @@ class WeatherWorker(
                 return
             }
 
-            FirebaseServiceHelper.uploadWeather(userEmail, deviceId, weatherMap)
-
-            Log.d(TAG, "Weather data uploaded to Firestore")
+            val success = FirebaseServiceHelper.uploadWeather(userEmail, deviceId, weatherMap)
+            val sanitizedEmail = FirebaseServiceHelper.sanitizeEmailForFirestore(userEmail)
+            if (success) {
+                Log.d(
+                    TAG,
+                    "Weather data uploaded to users/$sanitizedEmail/devices/$deviceId/weather"
+                )
+            } else {
+                Log.e(TAG, "Failed to upload weather data to Firestore")
+            }
         } catch (e: Exception) {
             Log.e(TAG, "Failed to upload weather data", e)
         }


### PR DESCRIPTION
## Summary
- add debug logs to show exact Firestore path when uploading call logs and weather data
- simplify WeatherWorker now that helper handles Firestore writes

## Testing
- `./gradlew assembleDebug` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_685825344fc88328b1b27fc5d65799cb