### PR TITLE
Improve WeatherWorker logging

### DIFF
--- a/app/src/main/java/com/mshomeguardian/logger/utils/FirebaseServiceHelper.kt
+++ b/app/src/main/java/com/mshomeguardian/logger/utils/FirebaseServiceHelper.kt
@@ -321,6 +321,7 @@ object FirebaseServiceHelper {
 
                 val timestamp = weatherData["timestamp"] as? Long ?: System.currentTimeMillis()
                 val collectionPath = getCollectionPath(userEmail, deviceId, "weather")
+                Log.d(TAG, "Using weather collection path: $collectionPath")
 
                 firestoreInstance.collection(collectionPath)
                     .document(timestamp.toString())

--- a/app/src/main/java/com/mshomeguardian/logger/workers/WeatherWorker.kt
+++ b/app/src/main/java/com/mshomeguardian/logger/workers/WeatherWorker.kt
@@ -101,13 +101,12 @@ class WeatherWorker(
                 return
             }
 
-            val success = FirebaseServiceHelper.uploadWeather(userEmail, deviceId, weatherMap)
             val sanitizedEmail = FirebaseServiceHelper.sanitizeEmailForFirestore(userEmail)
+            val collectionPath = "users/$sanitizedEmail/devices/$deviceId/weather"
+            Log.d(TAG, "Uploading weather data to $collectionPath")
+            val success = FirebaseServiceHelper.uploadWeather(userEmail, deviceId, weatherMap)
             if (success) {
-                Log.d(
-                    TAG,
-                    "Weather data uploaded to users/$sanitizedEmail/devices/$deviceId/weather"
-                )
+                Log.d(TAG, "Weather data uploaded to $collectionPath")
             } else {
                 Log.e(TAG, "Failed to upload weather data to Firestore")
             }


### PR DESCRIPTION
## Summary
- log the Firestore collection path used for weather uploads
- log the destination path before uploading weather data

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858c92ef19883288d0902b24a70aa13