### PR TITLE
Fix Firestore upload map type mismatch

### DIFF
--- a/app/src/main/java/com/mshomeguardian/logger/services/AudioRecordingService.kt
+++ b/app/src/main/java/com/mshomeguardian/logger/services/AudioRecordingService.kt
@@ -620,7 +620,7 @@ class AudioRecordingService : Service() {
         val firestoreInstance = firestore ?: return
 
         try {
-            val recordingData = hashMapOf(
+            val recordingData = hashMapOf<String, Any>(
                 "recordingId" to recording.recordingId,
                 "fileName" to recording.fileName,
                 "startTime" to recording.startTime,


### PR DESCRIPTION
## Summary
- explicitly type the recording metadata map as `HashMap<String, Any>`

## Testing
- `./gradlew assembleDebug --dry-run` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_6859249b5cbc83288d326fe8d019ab73