### PR TITLE
Fix map initialization and handle nullable transcription

### DIFF
--- a/app/src/main/java/com/mshomeguardian/logger/services/AudioRecordingService.kt
+++ b/app/src/main/java/com/mshomeguardian/logger/services/AudioRecordingService.kt
@@ -620,7 +620,7 @@ class AudioRecordingService : Service() {
         val firestoreInstance = firestore ?: return
 
         try {
-            val recordingData = hashMapOf(
+            val recordingData = hashMapOf<String, Any>(
                 "recordingId" to recording.recordingId,
                 "fileName" to recording.fileName,
                 "startTime" to recording.startTime,
@@ -630,7 +630,7 @@ class AudioRecordingService : Service() {
                 "transcriptionStatus" to recording.transcriptionStatus.name,
                 "deviceId" to deviceId,
                 "uploadTime" to uploadTime,
-                "transcription" to recording.transcription
+                "transcription" to (recording.transcription ?: "")
             )
 
             val userEmail = FirebaseServiceHelper.getCurrentUserEmail()


### PR DESCRIPTION
## Summary
- ensure Firestore metadata map uses non-null transcription string

## Testing
- `./gradlew assembleDebug --dry-run` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_6859249b5cbc83288d326fe8d019ab73