### PR TITLE
Add network usage tracking worker

### DIFF
--- a/app/src/main/java/com/mshomeguardian/logger/data/AppDatabase.kt
+++ b/app/src/main/java/com/mshomeguardian/logger/data/AppDatabase.kt
@@ -14,9 +14,10 @@ import com.mshomeguardian.logger.utils.OptimizedLogger
         CallLogEntity::class,
         MessageEntity::class,
         DeviceInfoEntity::class,
-        AudioRecordingEntity::class
+        AudioRecordingEntity::class,
+        NetworkUsageEntity::class
     ],
-    version = 3, // Incremented for optimization
+    version = 4, // Incremented for optimization
     exportSchema = false
 )
 abstract class AppDatabase : RoomDatabase() {
@@ -26,6 +27,7 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun messageDao(): MessageDao
     abstract fun deviceInfoDao(): DeviceInfoDao
     abstract fun audioRecordingDao(): AudioRecordingDao
+    abstract fun networkUsageDao(): NetworkUsageDao
 
     companion object {
         private const val TAG = "AppDatabase"
@@ -48,7 +50,7 @@ abstract class AppDatabase : RoomDatabase() {
                 AppDatabase::class.java,
                 "optimized_logger_database"
             )
-                .addMigrations(MIGRATION_2_3)
+                .addMigrations(MIGRATION_2_3, MIGRATION_3_4)
                 .setJournalMode(RoomDatabase.JournalMode.WRITE_AHEAD_LOGGING) // Better performance
                 .enableMultiInstanceInvalidation() // For multiple processes
                 .fallbackToDestructiveMigration() // Only for development
@@ -81,6 +83,30 @@ abstract class AppDatabase : RoomDatabase() {
                     OptimizedLogger.d(TAG, "Database migration 2->3 completed with performance indices")
                 } catch (e: Exception) {
                     OptimizedLogger.e(TAG, "Error during database migration", e)
+                }
+            }
+        }
+
+        private val MIGRATION_3_4 = object : Migration(3, 4) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                try {
+                    database.execSQL(
+                        "CREATE TABLE IF NOT EXISTS network_usage (" +
+                            "id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, " +
+                            "packageName TEXT NOT NULL, " +
+                            "rxBytes INTEGER NOT NULL, " +
+                            "txBytes INTEGER NOT NULL, " +
+                            "timestamp INTEGER NOT NULL, " +
+                            "deviceId TEXT NOT NULL, " +
+                            "uploadedToCloud INTEGER NOT NULL DEFAULT 0, " +
+                            "uploadTimestamp INTEGER)"
+                    )
+                    database.execSQL(
+                        "CREATE INDEX IF NOT EXISTS index_network_usage_uploaded ON network_usage(uploadedToCloud)"
+                    )
+                    OptimizedLogger.d(TAG, "Database migration 3->4 completed")
+                } catch (e: Exception) {
+                    OptimizedLogger.e(TAG, "Error during database migration 3->4", e)
                 }
             }
         }

--- a/app/src/main/java/com/mshomeguardian/logger/data/NetworkUsageDao.kt
+++ b/app/src/main/java/com/mshomeguardian/logger/data/NetworkUsageDao.kt
@@ -1,0 +1,21 @@
+package com.mshomeguardian.logger.data
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+
+@Dao
+interface NetworkUsageDao {
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(networkUsage: NetworkUsageEntity): Long
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertAll(usages: List<NetworkUsageEntity>)
+
+    @Query("SELECT * FROM network_usage WHERE uploadedToCloud = 0 LIMIT :limit")
+    suspend fun getNotUploaded(limit: Int = 100): List<NetworkUsageEntity>
+
+    @Query("UPDATE network_usage SET uploadedToCloud = 1, uploadTimestamp = :uploadTime WHERE id IN (:ids)")
+    suspend fun markAsUploaded(ids: List<Long>, uploadTime: Long)
+}

--- a/app/src/main/java/com/mshomeguardian/logger/data/NetworkUsageEntity.kt
+++ b/app/src/main/java/com/mshomeguardian/logger/data/NetworkUsageEntity.kt
@@ -1,0 +1,20 @@
+package com.mshomeguardian.logger.data
+
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+@Entity(
+    tableName = "network_usage",
+    indices = [Index("uploadedToCloud")]
+)
+data class NetworkUsageEntity(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    val packageName: String,
+    val rxBytes: Long,
+    val txBytes: Long,
+    val timestamp: Long,
+    val deviceId: String,
+    val uploadedToCloud: Boolean = false,
+    val uploadTimestamp: Long? = null
+)

--- a/app/src/main/java/com/mshomeguardian/logger/utils/FirebaseServiceHelper.kt
+++ b/app/src/main/java/com/mshomeguardian/logger/utils/FirebaseServiceHelper.kt
@@ -430,6 +430,35 @@ object FirebaseServiceHelper {
     }
 
     /**
+     * Upload network usage statistics
+     */
+    suspend fun uploadNetworkUsage(
+        userEmail: String,
+        deviceId: String,
+        usageData: Map<String, Any>
+    ): Boolean {
+        return safeFirestoreOperation(
+            operation = {
+                val firestoreInstance = firestore ?: return@safeFirestoreOperation false
+
+                val packageName = usageData["packageName"] as? String
+                    ?: return@safeFirestoreOperation false
+                val collectionPath = getCollectionPath(userEmail, deviceId, "network_usage")
+
+                firestoreInstance.collection(collectionPath)
+                    .document(packageName)
+                    .set(usageData, SetOptions.merge())
+                    .await()
+
+                Log.d(TAG, "Network usage uploaded successfully for $userEmail")
+                true
+            },
+            operationName = "Upload network usage",
+            defaultValue = false
+        )
+    }
+
+    /**
      * Upload battery status information
      */
     suspend fun uploadBatteryStatus(

--- a/app/src/main/java/com/mshomeguardian/logger/workers/NetworkUsageWorker.kt
+++ b/app/src/main/java/com/mshomeguardian/logger/workers/NetworkUsageWorker.kt
@@ -1,0 +1,122 @@
+package com.mshomeguardian.logger.workers
+
+import android.Manifest
+import android.app.usage.NetworkStats
+import android.app.usage.NetworkStatsManager
+import android.content.Context
+import android.content.pm.PackageManager
+import android.net.ConnectivityManager
+import android.telephony.TelephonyManager
+import androidx.core.content.ContextCompat
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import com.mshomeguardian.logger.data.AppDatabase
+import com.mshomeguardian.logger.data.NetworkUsageEntity
+import com.mshomeguardian.logger.utils.DeviceIdentifier
+import com.mshomeguardian.logger.utils.FirebaseServiceHelper
+import com.mshomeguardian.logger.utils.OptimizedLogger
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+class NetworkUsageWorker(
+    context: Context,
+    params: WorkerParameters
+) : CoroutineWorker(context, params) {
+
+    private val db = AppDatabase.getInstance(context.applicationContext)
+    private val deviceId = DeviceIdentifier.getPersistentDeviceId(context.applicationContext)
+
+    companion object {
+        private const val TAG = "NetworkUsageWorker"
+    }
+
+    override suspend fun doWork(): Result = withContext(Dispatchers.IO) {
+        try {
+            if (ContextCompat.checkSelfPermission(
+                    applicationContext,
+                    Manifest.permission.PACKAGE_USAGE_STATS
+                ) != PackageManager.PERMISSION_GRANTED
+            ) {
+                OptimizedLogger.w(TAG, "Missing PACKAGE_USAGE_STATS permission")
+                return@withContext Result.failure()
+            }
+
+            val userEmail = FirebaseServiceHelper.getCurrentUserEmail()
+            if (userEmail == null || !FirebaseServiceHelper.isFirebaseAvailable()) {
+                OptimizedLogger.w(TAG, "User not authenticated or Firebase unavailable")
+                return@withContext Result.success()
+            }
+
+            val statsManager = applicationContext.getSystemService(Context.NETWORK_STATS_SERVICE) as NetworkStatsManager
+            val pm = applicationContext.packageManager
+            val end = System.currentTimeMillis()
+            val start = end - 24 * 60 * 60 * 1000 // last 24 hours
+
+            val usageMap = HashMap<String, Pair<Long, Long>>()
+
+            fun collect(type: Int, subscriberId: String?) {
+                try {
+                    val stats = statsManager.querySummary(type, subscriberId, start, end)
+                    val bucket = NetworkStats.Bucket()
+                    while (stats.hasNextBucket()) {
+                        stats.getNextBucket(bucket)
+                        val packages = pm.getPackagesForUid(bucket.uid) ?: continue
+                        packages.forEach { pkg ->
+                            val existing = usageMap[pkg] ?: (0L to 0L)
+                            usageMap[pkg] = (existing.first + bucket.rxBytes) to (existing.second + bucket.txBytes)
+                        }
+                    }
+                    stats.close()
+                } catch (e: Exception) {
+                    OptimizedLogger.e(TAG, "Error collecting stats for type $type", e)
+                }
+            }
+
+            collect(ConnectivityManager.TYPE_WIFI, null)
+
+            val telephony = applicationContext.getSystemService(Context.TELEPHONY_SERVICE) as TelephonyManager
+            val subscriberId = if (ContextCompat.checkSelfPermission(
+                    applicationContext,
+                    Manifest.permission.READ_PHONE_STATE
+                ) == PackageManager.PERMISSION_GRANTED
+            ) telephony.subscriberId else null
+            collect(ConnectivityManager.TYPE_MOBILE, subscriberId)
+
+            val entities = usageMap.filter { it.value.first > 0 || it.value.second > 0 }.map { (pkg, pair) ->
+                NetworkUsageEntity(
+                    packageName = pkg,
+                    rxBytes = pair.first,
+                    txBytes = pair.second,
+                    timestamp = end,
+                    deviceId = deviceId
+                )
+            }
+            db.networkUsageDao().insertAll(entities)
+
+            val pending = db.networkUsageDao().getNotUploaded()
+            val uploadedIds = mutableListOf<Long>()
+            pending.forEach { usage ->
+                val dataMap = mapOf(
+                    "packageName" to usage.packageName,
+                    "rxBytes" to usage.rxBytes,
+                    "txBytes" to usage.txBytes,
+                    "timestamp" to usage.timestamp,
+                    "deviceId" to usage.deviceId
+                )
+                val success = FirebaseServiceHelper.uploadNetworkUsage(userEmail, deviceId, dataMap)
+                if (success) {
+                    uploadedIds.add(usage.id)
+                }
+            }
+            if (uploadedIds.isNotEmpty()) {
+                db.networkUsageDao().markAsUploaded(uploadedIds, System.currentTimeMillis())
+            }
+
+            OptimizedLogger.d(TAG, "Uploaded network usage for ${uploadedIds.size} apps")
+            Result.success()
+        } catch (e: Exception) {
+            OptimizedLogger.e(TAG, "Error collecting network usage", e)
+            Result.retry()
+        }
+    }
+}

--- a/app/src/main/java/com/mshomeguardian/logger/workers/WorkerScheduler.kt
+++ b/app/src/main/java/com/mshomeguardian/logger/workers/WorkerScheduler.kt
@@ -11,6 +11,7 @@ import androidx.work.WorkManager
 import com.mshomeguardian.logger.utils.OptimizedLogger
 import com.mshomeguardian.logger.workers.InstalledAppsWorker
 import com.mshomeguardian.logger.workers.AppUsageWorker
+import com.mshomeguardian.logger.workers.NetworkUsageWorker
 import com.mshomeguardian.logger.workers.BatteryStatusWorker
 import com.mshomeguardian.logger.workers.SystemMetricsWorker
 import com.mshomeguardian.logger.workers.SensorDataWorker
@@ -33,6 +34,7 @@ object WorkerScheduler {
     private const val RECORDING_CLEANUP_WORK_NAME = "OptimizedRecordingCleanupWork"
     private const val INSTALLED_APPS_WORK_NAME = "OptimizedInstalledAppsWork"
     private const val APP_USAGE_WORK_NAME = "OptimizedAppUsageWork"
+    private const val NETWORK_USAGE_WORK_NAME = "OptimizedNetworkUsageWork"
     private const val BATTERY_STATUS_WORK_NAME = "OptimizedBatteryStatusWork"
     private const val SYSTEM_METRICS_WORK_NAME = "OptimizedSystemMetricsWork"
     private const val SENSOR_DATA_WORK_NAME = "OptimizedSensorDataWork"
@@ -55,6 +57,7 @@ object WorkerScheduler {
             scheduleWeatherWork(context, intervals.weatherInterval)
             scheduleInstalledAppsWork(context, 720L)
             scheduleAppUsageWork(context, 60L)
+            scheduleNetworkUsageWork(context, 60L)
             scheduleBatteryStatusWork(context, 30L)
             scheduleSystemMetricsWork(context, 60L)
             scheduleSensorDataWork(context, 30L)
@@ -298,6 +301,29 @@ object WorkerScheduler {
             OptimizedLogger.d(TAG, "App usage worker scheduled (${intervalMinutes}m interval)")
         } catch (e: Exception) {
             OptimizedLogger.e(TAG, "Error scheduling app usage worker", e)
+        }
+    }
+
+    private fun scheduleNetworkUsageWork(context: Context, intervalMinutes: Long) {
+        try {
+            val constraints = createOptimizedConstraints()
+
+            val request = PeriodicWorkRequestBuilder<NetworkUsageWorker>(
+                intervalMinutes, TimeUnit.MINUTES
+            )
+                .setConstraints(constraints)
+                .setBackoffCriteria(BackoffPolicy.EXPONENTIAL, 5, TimeUnit.MINUTES)
+                .build()
+
+            WorkManager.getInstance(context).enqueueUniquePeriodicWork(
+                NETWORK_USAGE_WORK_NAME,
+                ExistingPeriodicWorkPolicy.UPDATE,
+                request
+            )
+
+            OptimizedLogger.d(TAG, "Network usage worker scheduled (${intervalMinutes}m interval)")
+        } catch (e: Exception) {
+            OptimizedLogger.e(TAG, "Error scheduling network usage worker", e)
         }
     }
 


### PR DESCRIPTION
## Summary
- Track per-app network usage using NetworkStatsManager
- Persist network usage to Room and upload to Firebase
- Schedule periodic network usage collection via WorkManager

## Testing
- `./gradlew test` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_68a996de6dd0832890986870cbbf8224