### PR TITLE
Add Room index to location entity to fix schema validation

### DIFF
--- a/app/src/main/java/com/mshomeguardian/logger/data/AppDatabase.kt
+++ b/app/src/main/java/com/mshomeguardian/logger/data/AppDatabase.kt
@@ -111,7 +111,6 @@ abstract class AppDatabase : RoomDatabase() {
                     "CREATE INDEX IF NOT EXISTS index_call_logs_timestamp_uploaded ON call_logs(timestamp, uploadedToCloud)",
                     "CREATE INDEX IF NOT EXISTS index_messages_timestamp_uploaded ON message_logs(timestamp, uploadedToCloud)",
                     "CREATE INDEX IF NOT EXISTS index_audio_uploaded_status ON audio_recordings(uploadedToCloud, transcriptionStatus)",
-                    "CREATE INDEX IF NOT EXISTS index_location_timestamp ON location_table(timestamp)",
                     "CREATE INDEX IF NOT EXISTS index_network_usage_uploaded ON network_usage(uploadedToCloud)"
                 )
 

--- a/app/src/main/java/com/mshomeguardian/logger/data/LocationEntity.kt
+++ b/app/src/main/java/com/mshomeguardian/logger/data/LocationEntity.kt
@@ -1,9 +1,13 @@
 package com.mshomeguardian.logger.data
 
 import androidx.room.Entity
+import androidx.room.Index
 import androidx.room.PrimaryKey
 
-@Entity(tableName = "location_table")
+@Entity(
+    tableName = "location_table",
+    indices = [Index(value = ["timestamp"], name = "index_location_timestamp")]
+)
 data class LocationEntity(
     @PrimaryKey val timestamp: Long,
     val latitude: Double,


### PR DESCRIPTION
## Summary
- Annotate `LocationEntity` with `@Index` on `timestamp` so Room's schema matches existing database
- Remove manual `location_table` index creation from startup helper

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b09b0894e48328baf7484012c40df3