### PR TITLE
Add Room index for timestamp upload

### DIFF
--- a/app/src/main/java/com/mshomeguardian/logger/data/CallLogEntity.kt
+++ b/app/src/main/java/com/mshomeguardian/logger/data/CallLogEntity.kt
@@ -13,7 +13,8 @@ import androidx.room.TypeConverters
     indices = [
         Index("callId", unique = true),
         Index("phoneNumber"),
-        Index("timestamp")
+        Index("timestamp"),
+        Index(value = ["timestamp", "uploadedToCloud"], name = "index_call_logs_timestamp_uploaded")
     ]
 )
 data class CallLogEntity(


### PR DESCRIPTION
## Summary
- declare `index_call_logs_timestamp_uploaded` on `CallLogEntity` to match migration and runtime schema

## Testing
- `./gradlew test` *(fails: Could not resolve dependencies due to SSLInitializationException: /usr/lib/jvm/java-17-openjdk-amd64/lib/security/cacerts (No such file or directory))*

------
https://chatgpt.com/codex/tasks/task_e_68b09f7a4188832890a18ec0322220a2