### PR TITLE
Align message table index with migration

### DIFF
--- a/app/src/main/java/com/mshomeguardian/logger/data/MessageEntity.kt
+++ b/app/src/main/java/com/mshomeguardian/logger/data/MessageEntity.kt
@@ -12,7 +12,8 @@ import androidx.room.PrimaryKey
     indices = [
         Index("messageId", unique = true),
         Index("phoneNumber"),
-        Index("timestamp")
+        Index("timestamp"),
+        Index(value = ["timestamp", "uploadedToCloud"], name = "index_messages_timestamp_uploaded")
     ]
 )
 data class MessageEntity(


### PR DESCRIPTION
## Summary
- include `timestamp`/`uploadedToCloud` index in `MessageEntity` so Room's schema matches the index created during migrations

## Testing
- `./gradlew test` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_68b0a528037883288f93c9380862bff8