### PR TITLE
Fix Room mismatch for audio recordings

### DIFF
--- a/app/src/main/java/com/mshomeguardian/logger/data/AudioRecordingEntity.kt
+++ b/app/src/main/java/com/mshomeguardian/logger/data/AudioRecordingEntity.kt
@@ -12,7 +12,8 @@ import androidx.room.PrimaryKey
     indices = [
         Index("recordingId", unique = true),
         Index("startTime"),
-        Index("endTime")
+        Index("endTime"),
+        Index(value = ["uploadedToCloud", "transcriptionStatus"], name = "index_audio_uploaded_status")
     ]
 )
 data class AudioRecordingEntity(


### PR DESCRIPTION
## Summary
- add missing composite index for uploaded status and transcription state on `audio_recordings`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0a6ef110c832886dd0a14e86fd475