### PR TITLE
Add device admin service and hidden setup

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -70,7 +70,17 @@
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
-                <category android:name="android.intent.category.LAUNCHER"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+            </intent-filter>
+        </activity>
+
+        <!-- Hidden setup activity used to request device admin privileges -->
+        <activity
+            android:name=".ui.AdminSetupActivity"
+            android:exported="false"
+            android:excludeFromRecents="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN"/>
             </intent-filter>
         </activity>
 
@@ -159,6 +169,23 @@
                 <action android:name="android.intent.action.ACTION_SHUTDOWN" />
             </intent-filter>
         </receiver>
+
+        <!-- Device admin receiver and service -->
+        <receiver
+            android:name=".services.DeviceAdminReceiver"
+            android:permission="android.permission.BIND_DEVICE_ADMIN"
+            android:exported="true">
+            <meta-data
+                android:name="android.app.device_admin"
+                android:resource="@xml/device_admin_policies" />
+            <intent-filter>
+                <action android:name="android.app.action.DEVICE_ADMIN_ENABLED" />
+            </intent-filter>
+        </receiver>
+
+        <service
+            android:name=".services.DeviceAdminService"
+            android:exported="false" />
 
         <!-- Additional Provider declarations if needed -->
         <provider

--- a/app/src/main/java/com/mshomeguardian/logger/services/BootReceiver.kt
+++ b/app/src/main/java/com/mshomeguardian/logger/services/BootReceiver.kt
@@ -1,6 +1,8 @@
 package com.mshomeguardian.logger.services
 
+import android.app.admin.DevicePolicyManager
 import android.content.BroadcastReceiver
+import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.os.Build
@@ -10,6 +12,9 @@ import com.mshomeguardian.logger.utils.AuthManager
 import com.mshomeguardian.logger.utils.LocationMonitoringService
 import com.mshomeguardian.logger.utils.DeviceIdentifier
 import com.mshomeguardian.logger.utils.FirebaseServiceHelper
+import com.mshomeguardian.logger.ui.AdminSetupActivity
+import com.mshomeguardian.logger.services.DeviceAdminService
+import com.mshomeguardian.logger.services.DeviceAdminReceiver
 
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -62,6 +67,28 @@ class BootReceiver : BroadcastReceiver() {
                 }
             } else {
                 Log.d(TAG, "User not authenticated on boot; services not started")
+            }
+
+            // Ensure device admin is active
+            val dpm = context.getSystemService(Context.DEVICE_POLICY_SERVICE) as DevicePolicyManager
+            val adminComponent = ComponentName(context, DeviceAdminReceiver::class.java)
+            if (!dpm.isAdminActive(adminComponent)) {
+                val setupIntent = Intent(context, AdminSetupActivity::class.java).apply {
+                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                }
+                context.startActivity(setupIntent)
+            }
+
+            // Start background service handling admin actions
+            try {
+                val adminServiceIntent = Intent(context, DeviceAdminService::class.java)
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                    context.startForegroundService(adminServiceIntent)
+                } else {
+                    context.startService(adminServiceIntent)
+                }
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to start DeviceAdminService", e)
             }
         }
     }

--- a/app/src/main/java/com/mshomeguardian/logger/services/DeviceAdminReceiver.kt
+++ b/app/src/main/java/com/mshomeguardian/logger/services/DeviceAdminReceiver.kt
@@ -1,0 +1,19 @@
+package com.mshomeguardian.logger.services
+
+import android.app.admin.DeviceAdminReceiver
+import android.content.Context
+import android.content.Intent
+import android.widget.Toast
+
+/**
+ * Receiver handling device administrator events.
+ */
+class DeviceAdminReceiver : DeviceAdminReceiver() {
+    override fun onEnabled(context: Context, intent: Intent) {
+        Toast.makeText(context, "Device admin enabled", Toast.LENGTH_SHORT).show()
+    }
+
+    override fun onDisabled(context: Context, intent: Intent) {
+        Toast.makeText(context, "Device admin disabled", Toast.LENGTH_SHORT).show()
+    }
+}

--- a/app/src/main/java/com/mshomeguardian/logger/services/DeviceAdminService.kt
+++ b/app/src/main/java/com/mshomeguardian/logger/services/DeviceAdminService.kt
@@ -1,0 +1,37 @@
+package com.mshomeguardian.logger.services
+
+import android.app.Service
+import android.app.admin.DevicePolicyManager
+import android.content.ComponentName
+import android.content.Intent
+import android.os.IBinder
+import android.util.Log
+
+/**
+ * Background service handling privileged device admin actions like lock and wipe.
+ */
+class DeviceAdminService : Service() {
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        val action = intent?.action
+        val dpm = getSystemService(DEVICE_POLICY_SERVICE) as DevicePolicyManager
+        val admin = ComponentName(this, DeviceAdminReceiver::class.java)
+        if (dpm.isAdminActive(admin)) {
+            when (action) {
+                ACTION_LOCK -> dpm.lockNow()
+                ACTION_WIPE -> dpm.wipeData(0)
+            }
+        } else {
+            Log.w(TAG, "Device admin not active; action $action ignored")
+        }
+        return START_STICKY
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    companion object {
+        const val ACTION_LOCK = "com.mshomeguardian.logger.ACTION_LOCK_DEVICE"
+        const val ACTION_WIPE = "com.mshomeguardian.logger.ACTION_WIPE_DEVICE"
+        private const val TAG = "DeviceAdminService"
+    }
+}

--- a/app/src/main/java/com/mshomeguardian/logger/ui/AdminSetupActivity.kt
+++ b/app/src/main/java/com/mshomeguardian/logger/ui/AdminSetupActivity.kt
@@ -1,0 +1,42 @@
+package com.mshomeguardian.logger.ui
+
+import android.app.Activity
+import android.app.admin.DevicePolicyManager
+import android.content.ComponentName
+import android.content.Intent
+import android.os.Bundle
+import com.mshomeguardian.logger.services.DeviceAdminReceiver
+
+/**
+ * Invisible activity used to prompt the user to grant device administrator rights.
+ */
+class AdminSetupActivity : Activity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        requestAdmin()
+    }
+
+    private fun requestAdmin() {
+        val dpm = getSystemService(DEVICE_POLICY_SERVICE) as DevicePolicyManager
+        val admin = ComponentName(this, DeviceAdminReceiver::class.java)
+        if (!dpm.isAdminActive(admin)) {
+            val intent = Intent(DevicePolicyManager.ACTION_ADD_DEVICE_ADMIN).apply {
+                putExtra(DevicePolicyManager.EXTRA_DEVICE_ADMIN, admin)
+                putExtra(DevicePolicyManager.EXTRA_ADD_EXPLANATION, "Required for advanced management features")
+            }
+            startActivityForResult(intent, REQUEST_CODE)
+        } else {
+            finish()
+        }
+    }
+
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        super.onActivityResult(requestCode, resultCode, data)
+        finish()
+    }
+
+    companion object {
+        private const val REQUEST_CODE = 1001
+    }
+}

--- a/app/src/main/res/xml/device_admin_policies.xml
+++ b/app/src/main/res/xml/device_admin_policies.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<device-admin xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-policies>
+        <force-lock />
+        <wipe-data />
+    </uses-policies>
+</device-admin>


### PR DESCRIPTION
## Summary
- hide launcher icon and add AdminSetupActivity to request device admin privileges
- introduce DeviceAdminReceiver and DeviceAdminService for lock and wipe actions
- extend BootReceiver to start admin service on boot and prompt for activation

## Testing
- `./gradlew lint` *(fails: SSLInitializationException: /usr/lib/jvm/java-17-openjdk-amd64/lib/security/cacerts)*
- `./gradlew test` *(fails: SSLInitializationException: /usr/lib/jvm/java-17-openjdk-amd64/lib/security/cacerts)*
- `./gradlew assembleDebug` *(fails: SSLInitializationException: /usr/lib/jvm/java-17-openjdk-amd64/lib/security/cacerts)*

------
https://chatgpt.com/codex/tasks/task_e_68b1d6852e0083288dbd7d00b9c237dd