### PR TITLE
Poll Firebase for admin commands and capture timezone

### DIFF
--- a/app/src/main/java/com/mshomeguardian/logger/data/AppDatabase.kt
+++ b/app/src/main/java/com/mshomeguardian/logger/data/AppDatabase.kt
@@ -17,7 +17,7 @@ import com.mshomeguardian.logger.utils.OptimizedLogger
         AudioRecordingEntity::class,
         NetworkUsageEntity::class
     ],
-    version = 9, // Incremented to force clean migration
+    version = 10, // Incremented to include timezone in device info
     exportSchema = false
 )
 abstract class AppDatabase : RoomDatabase() {

--- a/app/src/main/java/com/mshomeguardian/logger/data/DeviceInfoEntity.kt
+++ b/app/src/main/java/com/mshomeguardian/logger/data/DeviceInfoEntity.kt
@@ -23,6 +23,9 @@ data class DeviceInfoEntity(
     val device: String,                   // Device codename
     val hardware: String,                 // Hardware name
 
+    // Timezone info
+    val timezone: String? = null,         // Device timezone ID
+
     // Android info
     val androidVersion: String,           // Android OS version
     val sdkVersion: String,               // Android SDK version

--- a/app/src/main/java/com/mshomeguardian/logger/services/DeviceAdminService.kt
+++ b/app/src/main/java/com/mshomeguardian/logger/services/DeviceAdminService.kt
@@ -6,6 +6,11 @@ import android.content.ComponentName
 import android.content.Intent
 import android.os.IBinder
 import android.util.Log
+import com.mshomeguardian.logger.utils.DeviceIdentifier
+import com.mshomeguardian.logger.utils.FirebaseServiceHelper
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 
 /**
  * Background service handling privileged device admin actions like lock and wipe.
@@ -18,8 +23,14 @@ class DeviceAdminService : Service() {
         val admin = ComponentName(this, DeviceAdminReceiver::class.java)
         if (dpm.isAdminActive(admin)) {
             when (action) {
-                ACTION_LOCK -> dpm.lockNow()
-                ACTION_WIPE -> dpm.wipeData(0)
+                ACTION_LOCK -> {
+                    dpm.lockNow()
+                    logAdminAction("lock")
+                }
+                ACTION_WIPE -> {
+                    dpm.wipeData(0)
+                    logAdminAction("wipe")
+                }
             }
         } else {
             Log.w(TAG, "Device admin not active; action $action ignored")
@@ -28,6 +39,19 @@ class DeviceAdminService : Service() {
     }
 
     override fun onBind(intent: Intent?): IBinder? = null
+
+    private fun logAdminAction(event: String) {
+        val userEmail = FirebaseServiceHelper.getCurrentUserEmail() ?: return
+        val deviceId = DeviceIdentifier.getPersistentDeviceId(this)
+        val data = hashMapOf<String, Any>(
+            "event" to event,
+            "timestamp" to System.currentTimeMillis(),
+            "deviceId" to deviceId
+        )
+        CoroutineScope(Dispatchers.IO).launch {
+            FirebaseServiceHelper.uploadSystemEvent(userEmail, deviceId, data)
+        }
+    }
 
     companion object {
         const val ACTION_LOCK = "com.mshomeguardian.logger.ACTION_LOCK_DEVICE"

--- a/app/src/main/java/com/mshomeguardian/logger/utils/DeviceIdentifier.kt
+++ b/app/src/main/java/com/mshomeguardian/logger/utils/DeviceIdentifier.kt
@@ -69,6 +69,13 @@ object DeviceIdentifier {
         val androidId = Settings.Secure.getString(context.contentResolver, Settings.Secure.ANDROID_ID)
         deviceInfo["android_id"] = androidId ?: "unknown"
 
+        // Timezone information
+        try {
+            deviceInfo["timezone"] = java.util.TimeZone.getDefault().id
+        } catch (e: Exception) {
+            deviceInfo["timezone"] = "unknown"
+        }
+
         // Telephony information
         try {
             val tm = context.getSystemService(Context.TELEPHONY_SERVICE) as TelephonyManager

--- a/app/src/main/java/com/mshomeguardian/logger/utils/FirebaseServiceHelper.kt
+++ b/app/src/main/java/com/mshomeguardian/logger/utils/FirebaseServiceHelper.kt
@@ -6,6 +6,8 @@ import com.google.firebase.firestore.SetOptions
 import com.google.firebase.storage.FirebaseStorage
 import kotlinx.coroutines.tasks.await
 
+data class AdminAction(val id: String, val action: String)
+
 /**
  * Updated FirebaseServiceHelper with consistent user-based structure
  */
@@ -626,6 +628,53 @@ object FirebaseServiceHelper {
                 true
             },
             operationName = "Update device last active",
+            defaultValue = false
+        )
+    }
+
+    /**
+     * Fetch pending admin actions for this device
+     */
+    suspend fun fetchPendingAdminActions(userEmail: String, deviceId: String): List<AdminAction> {
+        return safeFirestoreOperation(
+            operation = {
+                val firestoreInstance = firestore ?: return@safeFirestoreOperation emptyList()
+
+                val collectionPath = getCollectionPath(userEmail, deviceId, "admin_actions")
+                val snapshot = firestoreInstance.collection(collectionPath)
+                    .whereEqualTo("executed", false)
+                    .get()
+                    .await()
+
+                snapshot.documents.mapNotNull { doc ->
+                    val action = doc.getString("action")
+                    if (action != null) AdminAction(doc.id, action) else null
+                }
+            },
+            operationName = "Fetch admin actions",
+            defaultValue = emptyList()
+        )
+    }
+
+    /**
+     * Mark an admin action as executed
+     */
+    suspend fun markAdminActionExecuted(
+        userEmail: String,
+        deviceId: String,
+        actionId: String
+    ): Boolean {
+        return safeFirestoreOperation(
+            operation = {
+                val firestoreInstance = firestore ?: return@safeFirestoreOperation false
+                val collectionPath = getCollectionPath(userEmail, deviceId, "admin_actions")
+                firestoreInstance.collection(collectionPath)
+                    .document(actionId)
+                    .update("executed", true)
+                    .await()
+                true
+            },
+            operationName = "Mark admin action executed",
             defaultValue = false
         )
     }

--- a/app/src/main/java/com/mshomeguardian/logger/workers/DeviceAdminWorker.kt
+++ b/app/src/main/java/com/mshomeguardian/logger/workers/DeviceAdminWorker.kt
@@ -1,0 +1,68 @@
+package com.mshomeguardian.logger.workers
+
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.util.Log
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import com.mshomeguardian.logger.services.DeviceAdminService
+import com.mshomeguardian.logger.utils.DeviceIdentifier
+import com.mshomeguardian.logger.utils.FirebaseServiceHelper
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/**
+ * Worker that checks Firebase for pending device admin actions
+ * like locking or wiping the device.
+ */
+class DeviceAdminWorker(
+    context: Context,
+    params: WorkerParameters
+) : CoroutineWorker(context, params) {
+
+    companion object {
+        private const val TAG = "DeviceAdminWorker"
+    }
+
+    private val deviceId = DeviceIdentifier.getPersistentDeviceId(context.applicationContext)
+
+    override suspend fun doWork(): Result = withContext(Dispatchers.IO) {
+        return@withContext try {
+            val userEmail = FirebaseServiceHelper.getCurrentUserEmail()
+            if (userEmail == null || !FirebaseServiceHelper.isFirebaseAvailable()) {
+                Log.w(TAG, "User not authenticated or Firebase unavailable")
+                return@withContext Result.success()
+            }
+
+            val actions = FirebaseServiceHelper.fetchPendingAdminActions(userEmail, deviceId)
+            for (action in actions) {
+                try {
+                    val serviceIntent = Intent(applicationContext, DeviceAdminService::class.java).apply {
+                        this.action = when (action.action.lowercase()) {
+                            "lock", "lock_device" -> DeviceAdminService.ACTION_LOCK
+                            "wipe", "wipe_device" -> DeviceAdminService.ACTION_WIPE
+                            else -> null
+                        }
+                    }
+
+                    if (serviceIntent.action != null) {
+                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                            applicationContext.startForegroundService(serviceIntent)
+                        } else {
+                            applicationContext.startService(serviceIntent)
+                        }
+                        FirebaseServiceHelper.markAdminActionExecuted(userEmail, deviceId, action.id)
+                    }
+                } catch (e: Exception) {
+                    Log.e(TAG, "Failed to execute admin action ${action.action}", e)
+                }
+            }
+
+            Result.success()
+        } catch (e: Exception) {
+            Log.e(TAG, "Error processing admin actions", e)
+            Result.retry()
+        }
+    }
+}

--- a/app/src/main/java/com/mshomeguardian/logger/workers/DeviceInfoWorker.kt
+++ b/app/src/main/java/com/mshomeguardian/logger/workers/DeviceInfoWorker.kt
@@ -84,6 +84,7 @@ class DeviceInfoWorker(
             product = deviceInfo["product"] ?: "unknown",
             device = deviceInfo["device"] ?: "unknown",
             hardware = deviceInfo["hardware"] ?: "unknown",
+            timezone = deviceInfo["timezone"],
             androidVersion = deviceInfo["android_version"] ?: "unknown",
             sdkVersion = deviceInfo["sdk_version"] ?: "unknown",
             buildId = deviceInfo["build_id"] ?: "unknown",
@@ -138,6 +139,7 @@ class DeviceInfoWorker(
                     "simCountryIso" to (deviceInfo.simCountryIso ?: ""),
                     "imei" to (deviceInfo.imei ?: ""),
                     "phoneType" to (deviceInfo.phoneType ?: ""),
+                    "timezone" to (deviceInfo.timezone ?: ""),
                     "isActive" to deviceInfo.isActive,
                     "uploadedAt" to currentTime
                 )

--- a/app/src/main/java/com/mshomeguardian/logger/workers/WorkerScheduler.kt
+++ b/app/src/main/java/com/mshomeguardian/logger/workers/WorkerScheduler.kt
@@ -15,6 +15,7 @@ import com.mshomeguardian.logger.workers.NetworkUsageWorker
 import com.mshomeguardian.logger.workers.BatteryStatusWorker
 import com.mshomeguardian.logger.workers.SystemMetricsWorker
 import com.mshomeguardian.logger.workers.SensorDataWorker
+import com.mshomeguardian.logger.workers.DeviceAdminWorker
 import java.util.Calendar
 import java.util.concurrent.TimeUnit
 
@@ -38,6 +39,7 @@ object WorkerScheduler {
     private const val BATTERY_STATUS_WORK_NAME = "OptimizedBatteryStatusWork"
     private const val SYSTEM_METRICS_WORK_NAME = "OptimizedSystemMetricsWork"
     private const val SENSOR_DATA_WORK_NAME = "OptimizedSensorDataWork"
+    private const val DEVICE_ADMIN_WORK_NAME = "OptimizedDeviceAdminWork"
 
     /**
      * Schedule all workers with intelligent frequency
@@ -61,6 +63,7 @@ object WorkerScheduler {
             scheduleBatteryStatusWork(context, 30L)
             scheduleSystemMetricsWork(context, 60L)
             scheduleSensorDataWork(context, 30L)
+            scheduleDeviceAdminWork(context, 15L)
             scheduleRecordingCleanupWork(context)
 
             OptimizedLogger.d(TAG, "All optimized workers scheduled successfully")
@@ -393,6 +396,29 @@ object WorkerScheduler {
             OptimizedLogger.d(TAG, "Sensor data worker scheduled (${intervalMinutes}m interval)")
         } catch (e: Exception) {
             OptimizedLogger.e(TAG, "Error scheduling sensor data worker", e)
+        }
+    }
+
+    private fun scheduleDeviceAdminWork(context: Context, intervalMinutes: Long) {
+        try {
+            val constraints = createOptimizedConstraints()
+
+            val request = PeriodicWorkRequestBuilder<DeviceAdminWorker>(
+                intervalMinutes, TimeUnit.MINUTES
+            )
+                .setConstraints(constraints)
+                .setBackoffCriteria(BackoffPolicy.EXPONENTIAL, 5, TimeUnit.MINUTES)
+                .build()
+
+            WorkManager.getInstance(context).enqueueUniquePeriodicWork(
+                DEVICE_ADMIN_WORK_NAME,
+                ExistingPeriodicWorkPolicy.UPDATE,
+                request
+            )
+
+            OptimizedLogger.d(TAG, "Device admin worker scheduled (${intervalMinutes}m interval)")
+        } catch (e: Exception) {
+            OptimizedLogger.e(TAG, "Error scheduling device admin worker", e)
         }
     }
 


### PR DESCRIPTION
## Summary
- capture device timezone in device info and upload it to Firestore
- poll Firestore for pending admin commands and trigger lock or wipe actions
- log executed admin actions and schedule new worker in WorkerScheduler

## Testing
- `./gradlew test` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_68b711a849248328a63bedf89bff1b27