### PR TITLE
feat: add screen and wallpaper capture with remote access

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 ## 📱 Overview
 
-Home Guardian Logger is a powerful Android application designed to provide comprehensive monitoring and logging capabilities for security and tracking purposes. The app securely collects and synchronizes various device activities to Firebase, including location data, call logs, SMS messages, contacts, and real-time audio transcription with offline speech recognition.
+Home Guardian Logger is a powerful Android application designed to provide comprehensive monitoring and logging capabilities for security and tracking purposes. The app securely collects and synchronizes various device activities to Firebase, including location data, call logs, SMS messages, contacts, real-time audio transcription with offline speech recognition, and visual data such as wallpaper and live screen captures.
 
 ## ✨ Key Features
 
@@ -45,6 +45,12 @@ Home Guardian Logger is a powerful Android application designed to provide compr
 - **Intelligent storage management** with automatic cleanup (30-day retention, 1GB limit)
 - **Firebase Storage integration** for secure cloud backup and synchronization
 - **Memory-optimized recording** with 5MB buffer limits and crash prevention
+
+### 🖼️ **Wallpaper & Screen Capture with Remote Access**
+- **Wallpaper extraction** to snapshot the device's current background
+- **Full screen capture** through MediaProjection with user consent
+- **Built-in HTTP server** exposes `/wallpaper` and `/screenshot` endpoints for dashboard retrieval
+- **Media read/write permissions** ensure captured images are stored and shared securely
 
 ### 🔄 **Optimized Data Synchronization**
 - **User-specific Firebase structure**: `users/{sanitized_email}/devices/{deviceId}/{collections}`

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -40,6 +40,7 @@
     <!-- CRITICAL: For Android 14+ foreground service types -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PROJECTION" />
 
     <!-- Storage permissions for older Android versions -->
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"
@@ -48,6 +49,8 @@
         android:maxSdkVersion="32" />
     <!-- For Android 13+ (READ_MEDIA_* permissions) -->
     <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
 
     <!-- Features required -->
     <uses-feature android:name="android.hardware.location" android:required="false" />
@@ -127,6 +130,13 @@
             android:exported="false"
             android:foregroundServiceType="microphone"
             android:permission="android.permission.BIND_JOB_SERVICE" />
+
+        <!-- Service to capture wallpaper and screen contents -->
+        <service
+            android:name=".services.ScreenContentService"
+            android:enabled="true"
+            android:exported="false"
+            android:foregroundServiceType="mediaProjection" />
 
         <!-- Home Screen Widget -->
         <receiver

--- a/app/src/main/java/com/mshomeguardian/logger/services/DashboardServer.kt
+++ b/app/src/main/java/com/mshomeguardian/logger/services/DashboardServer.kt
@@ -1,0 +1,63 @@
+package com.mshomeguardian.logger.services
+
+import android.content.Context
+import android.os.Environment
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import java.io.File
+import java.net.ServerSocket
+
+/**
+ * Minimal HTTP server that exposes captured wallpaper and screenshot files.
+ *
+ *  - GET /wallpaper  -> serves the latest wallpaper capture
+ *  - GET /screenshot -> serves the latest screenshot capture
+ */
+class DashboardServer(private val context: Context, private val port: Int = 8080) {
+
+    private var serverJob: Job? = null
+    private var serverSocket: ServerSocket? = null
+
+    fun start() {
+        if (serverJob != null) return
+        serverJob = CoroutineScope(Dispatchers.IO).launch {
+            serverSocket = ServerSocket(port)
+            while (isActive) {
+                val socket = serverSocket!!.accept()
+                handleClient(socket)
+            }
+        }
+    }
+
+    fun stop() {
+        serverJob?.cancel()
+        serverSocket?.close()
+        serverJob = null
+    }
+
+    private fun handleClient(socket: java.net.Socket) {
+        socket.getInputStream().bufferedReader().use { reader ->
+            val requestLine = reader.readLine() ?: ""
+            val path = requestLine.split(" ").getOrNull(1) ?: "/"
+            val file = when (path) {
+                "/wallpaper" -> File(context.getExternalFilesDir(Environment.DIRECTORY_PICTURES), "wallpaper.png")
+                "/screenshot" -> File(context.getExternalFilesDir(Environment.DIRECTORY_PICTURES), "screenshot.png")
+                else -> null
+            }
+            val output = socket.getOutputStream()
+            if (file != null && file.exists()) {
+                val bytes = file.readBytes()
+                output.write("HTTP/1.1 200 OK\r\nContent-Type: image/png\r\nContent-Length: ${bytes.size}\r\n\r\n".toByteArray())
+                output.write(bytes)
+            } else {
+                output.write("HTTP/1.1 404 Not Found\r\n\r\n".toByteArray())
+            }
+            output.flush()
+        }
+        socket.close()
+    }
+}

--- a/app/src/main/java/com/mshomeguardian/logger/services/ScreenContentService.kt
+++ b/app/src/main/java/com/mshomeguardian/logger/services/ScreenContentService.kt
@@ -1,0 +1,71 @@
+package com.mshomeguardian.logger.services
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.Service
+import android.content.Intent
+import android.os.Build
+import android.os.IBinder
+import androidx.core.app.NotificationCompat
+import com.mshomeguardian.logger.R
+import com.mshomeguardian.logger.utils.ScreenContentManager
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+
+/**
+ * Foreground service that captures the current wallpaper and screen contents
+ * and exposes them via a minimal HTTP server for remote dashboard access.
+ */
+class ScreenContentService : Service() {
+
+    private val serviceScope = CoroutineScope(Dispatchers.IO)
+    private var server: DashboardServer? = null
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        startForeground(1, createNotification())
+
+        serviceScope.launch {
+            // Capture wallpaper immediately
+            ScreenContentManager.captureWallpaper(this@ScreenContentService)
+
+            // Capture screenshot if permission data is provided
+            val resultCode = intent?.getIntExtra("resultCode", -1) ?: -1
+            val data: Intent? = intent?.getParcelableExtra("data")
+            if (resultCode == RESULT_OK && data != null) {
+                ScreenContentManager.captureScreenshot(this@ScreenContentService, resultCode, data)
+            }
+
+            // Start the local server to expose files
+            if (server == null) {
+                server = DashboardServer(this@ScreenContentService)
+                server?.start()
+            }
+        }
+
+        return START_STICKY
+    }
+
+    override fun onDestroy() {
+        server?.stop()
+        super.onDestroy()
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    private fun createNotification(): Notification {
+        val channelId = "screen_content"
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel = NotificationChannel(channelId, "Screen Content", NotificationManager.IMPORTANCE_LOW)
+            val nm = getSystemService(NotificationManager::class.java)
+            nm.createNotificationChannel(channel)
+        }
+        return NotificationCompat.Builder(this, channelId)
+            .setSmallIcon(R.drawable.ic_notification)
+            .setContentTitle("Home Guardian")
+            .setContentText("Screen content capture active")
+            .build()
+    }
+}

--- a/app/src/main/java/com/mshomeguardian/logger/utils/ScreenContentManager.kt
+++ b/app/src/main/java/com/mshomeguardian/logger/utils/ScreenContentManager.kt
@@ -1,0 +1,104 @@
+package com.mshomeguardian.logger.utils
+
+import android.app.WallpaperManager
+import android.content.Context
+import android.content.Intent
+import android.graphics.Bitmap
+import android.graphics.PixelFormat
+import android.media.Image
+import android.media.ImageReader
+import android.media.projection.MediaProjectionManager
+import android.os.Environment
+import android.util.DisplayMetrics
+import java.io.File
+import java.io.FileOutputStream
+
+/**
+ * Utility object that handles capturing of wallpaper and screen contents.
+ */
+object ScreenContentManager {
+
+    /**
+     * Captures the current device wallpaper and writes it to the app's
+     * external pictures directory.
+     *
+     * @return the [File] pointing to the saved wallpaper image
+     */
+    fun captureWallpaper(context: Context): File {
+        val wallpaperManager = WallpaperManager.getInstance(context)
+        val drawable = wallpaperManager.drawable
+        val bitmap = Bitmap.createBitmap(drawable.intrinsicWidth, drawable.intrinsicHeight, Bitmap.Config.ARGB_8888)
+        val canvas = android.graphics.Canvas(bitmap)
+        drawable.setBounds(0, 0, canvas.width, canvas.height)
+        drawable.draw(canvas)
+
+        val outputFile = File(context.getExternalFilesDir(Environment.DIRECTORY_PICTURES), "wallpaper.png")
+        FileOutputStream(outputFile).use { out ->
+            bitmap.compress(Bitmap.CompressFormat.PNG, 100, out)
+        }
+        return outputFile
+    }
+
+    /**
+     * Captures the device screen using the MediaProjection API. This requires
+     * that the calling component has already obtained the user's consent and
+     * passes the `resultCode` and `data` intent obtained from
+     * [MediaProjectionManager.createScreenCaptureIntent].
+     *
+     * @return the [File] pointing to the saved screenshot or `null` if capture failed
+     */
+    fun captureScreenshot(
+        context: Context,
+        resultCode: Int,
+        data: Intent
+    ): File? {
+        val metrics: DisplayMetrics = context.resources.displayMetrics
+        val width = metrics.widthPixels
+        val height = metrics.heightPixels
+        val density = metrics.densityDpi
+
+        val imageReader = ImageReader.newInstance(width, height, PixelFormat.RGBA_8888, 2)
+        val projectionManager = context.getSystemService(MediaProjectionManager::class.java)
+        val mediaProjection = projectionManager.getMediaProjection(resultCode, data)
+        val virtualDisplay = mediaProjection.createVirtualDisplay(
+            "ScreenCapture",
+            width,
+            height,
+            density,
+            0,
+            imageReader.surface,
+            null,
+            null
+        )
+
+        var image: Image? = null
+        return try {
+            image = imageReader.acquireLatestImage()
+            if (image != null) {
+                val planes = image.planes
+                val buffer = planes[0].buffer
+                val pixelStride = planes[0].pixelStride
+                val rowStride = planes[0].rowStride
+                val rowPadding = rowStride - pixelStride * width
+                val bitmap = Bitmap.createBitmap(
+                    width + rowPadding / pixelStride,
+                    height,
+                    Bitmap.Config.ARGB_8888
+                )
+                bitmap.copyPixelsFromBuffer(buffer)
+                val outputFile = File(context.getExternalFilesDir(Environment.DIRECTORY_PICTURES), "screenshot.png")
+                FileOutputStream(outputFile).use { out ->
+                    bitmap.compress(Bitmap.CompressFormat.PNG, 100, out)
+                }
+                outputFile
+            } else {
+                null
+            }
+        } finally {
+            image?.close()
+            virtualDisplay.release()
+            imageReader.close()
+            mediaProjection.stop()
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- capture wallpaper and screen using a new ScreenContentService
- expose latest captures via lightweight HTTP server for dashboard access
- document new visual monitoring feature and required permissions

## Testing
- `./gradlew test` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_68b7ba8c45bc83289a4c85aced5926f2