### PR TITLE
Fix wallpaper and screenshot capture compilation issues

### DIFF
--- a/app/src/main/java/com/mshomeguardian/logger/services/ScreenContentService.kt
+++ b/app/src/main/java/com/mshomeguardian/logger/services/ScreenContentService.kt
@@ -4,6 +4,7 @@ import android.app.Notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.Service
+import android.app.Activity.RESULT_OK
 import android.content.Intent
 import android.os.Build
 import android.os.IBinder
@@ -12,7 +13,6 @@ import com.mshomeguardian.logger.R
 import com.mshomeguardian.logger.utils.ScreenContentManager
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 
 /**

--- a/app/src/main/java/com/mshomeguardian/logger/utils/ScreenContentManager.kt
+++ b/app/src/main/java/com/mshomeguardian/logger/utils/ScreenContentManager.kt
@@ -26,8 +26,15 @@ object ScreenContentManager {
      */
     fun captureWallpaper(context: Context): File {
         val wallpaperManager = WallpaperManager.getInstance(context)
-        val drawable = wallpaperManager.drawable
-        val bitmap = Bitmap.createBitmap(drawable.intrinsicWidth, drawable.intrinsicHeight, Bitmap.Config.ARGB_8888)
+        val drawable = wallpaperManager.drawable ?: return File(
+            context.getExternalFilesDir(Environment.DIRECTORY_PICTURES),
+            "wallpaper.png"
+        ).apply { createNewFile() }
+        val bitmap = Bitmap.createBitmap(
+            drawable.intrinsicWidth,
+            drawable.intrinsicHeight,
+            Bitmap.Config.ARGB_8888
+        )
         val canvas = android.graphics.Canvas(bitmap)
         drawable.setBounds(0, 0, canvas.width, canvas.height)
         drawable.draw(canvas)


### PR DESCRIPTION
## Summary
- Import Activity.RESULT_OK to resolve screenshot permission check
- Guard against null wallpaper drawables before bitmap creation

## Testing
- `./gradlew assembleDebug` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_68b7bc9c5bb08328ad9ee1047da4abb9