### PR TITLE
Add device password change admin action

### DIFF
--- a/app/src/main/java/com/mshomeguardian/logger/services/DeviceAdminService.kt
+++ b/app/src/main/java/com/mshomeguardian/logger/services/DeviceAdminService.kt
@@ -19,7 +19,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
 /**
- * Background service handling privileged device admin actions like lock and wipe.
+ * Background service handling privileged device admin actions like lock, wipe, and password reset.
  */
 class DeviceAdminService : Service() {
 
@@ -41,6 +41,19 @@ class DeviceAdminService : Service() {
                 ACTION_WIPE -> {
                     dpm.wipeData(0)
                     logAdminAction("wipe")
+                }
+                ACTION_CHANGE_PASSWORD -> {
+                    val newPassword = intent.getStringExtra(EXTRA_NEW_PASSWORD)
+                    if (newPassword.isNullOrBlank()) {
+                        Log.w(TAG, "Password change action missing password payload")
+                    } else {
+                        val changed = resetDevicePassword(dpm, newPassword)
+                        if (changed) {
+                            logAdminAction("change_password")
+                        } else {
+                            Log.w(TAG, "Password change command failed")
+                        }
+                    }
                 }
             }
         } else {
@@ -93,9 +106,24 @@ class DeviceAdminService : Service() {
         )
     }
 
+    @Suppress("DEPRECATION")
+    private fun resetDevicePassword(dpm: DevicePolicyManager, password: String): Boolean {
+        return try {
+            dpm.resetPassword(password, DevicePolicyManager.RESET_PASSWORD_REQUIRE_ENTRY)
+        } catch (securityException: SecurityException) {
+            Log.e(TAG, "Password change rejected by device policy", securityException)
+            false
+        } catch (illegalArgumentException: IllegalArgumentException) {
+            Log.e(TAG, "Password change payload is invalid", illegalArgumentException)
+            false
+        }
+    }
+
     companion object {
         const val ACTION_LOCK = "com.mshomeguardian.logger.ACTION_LOCK_DEVICE"
         const val ACTION_WIPE = "com.mshomeguardian.logger.ACTION_WIPE_DEVICE"
+        const val ACTION_CHANGE_PASSWORD = "com.mshomeguardian.logger.ACTION_CHANGE_DEVICE_PASSWORD"
+        const val EXTRA_NEW_PASSWORD = "com.mshomeguardian.logger.EXTRA_NEW_DEVICE_PASSWORD"
         private const val TAG = "DeviceAdminService"
     }
 }

--- a/app/src/main/java/com/mshomeguardian/logger/utils/FirebaseServiceHelper.kt
+++ b/app/src/main/java/com/mshomeguardian/logger/utils/FirebaseServiceHelper.kt
@@ -6,7 +6,11 @@ import com.google.firebase.firestore.SetOptions
 import com.google.firebase.storage.FirebaseStorage
 import kotlinx.coroutines.tasks.await
 
-data class AdminAction(val id: String, val action: String)
+data class AdminAction(
+    val id: String,
+    val action: String,
+    val password: String? = null
+)
 
 /**
  * Updated FirebaseServiceHelper with consistent user-based structure
@@ -696,7 +700,15 @@ object FirebaseServiceHelper {
 
                 snapshot.documents.mapNotNull { doc ->
                     val action = doc.getString("action")
-                    if (action != null) AdminAction(doc.id, action) else null
+                    val payload = doc.get("payload") as? Map<*, *>
+                    val password = doc.getString("password")
+                        ?: doc.getString("newPassword")
+                        ?: (payload?.get("password") as? String)
+                    if (action != null) {
+                        AdminAction(doc.id, action, password)
+                    } else {
+                        null
+                    }
                 }
             },
             operationName = "Fetch admin actions",
@@ -718,7 +730,12 @@ object FirebaseServiceHelper {
                 val collectionPath = getCollectionPath(userEmail, deviceId, "admin_actions")
                 firestoreInstance.collection(collectionPath)
                     .document(actionId)
-                    .update("executed", true)
+                    .update(
+                        mapOf(
+                            "executed" to true,
+                            "action_performed_timestamp" to System.currentTimeMillis()
+                        )
+                    )
                     .await()
                 true
             },

--- a/app/src/main/java/com/mshomeguardian/logger/workers/DeviceAdminWorker.kt
+++ b/app/src/main/java/com/mshomeguardian/logger/workers/DeviceAdminWorker.kt
@@ -14,7 +14,7 @@ import kotlinx.coroutines.withContext
 
 /**
  * Worker that checks Firebase for pending device admin actions
- * like locking or wiping the device.
+ * like locking, wiping, or changing the device password.
  */
 class DeviceAdminWorker(
     context: Context,
@@ -42,6 +42,16 @@ class DeviceAdminWorker(
                         this.action = when (action.action.lowercase()) {
                             "lock", "lock_device" -> DeviceAdminService.ACTION_LOCK
                             "wipe", "wipe_device" -> DeviceAdminService.ACTION_WIPE
+                            "change_password", "set_password", "reset_password" -> {
+                                val password = action.password?.trim()
+                                if (password.isNullOrEmpty()) {
+                                    Log.w(TAG, "Password action ${action.id} missing password payload")
+                                    null
+                                } else {
+                                    putExtra(DeviceAdminService.EXTRA_NEW_PASSWORD, password)
+                                    DeviceAdminService.ACTION_CHANGE_PASSWORD
+                                }
+                            }
                             else -> null
                         }
                     }

--- a/app/src/main/res/xml/device_admin_policies.xml
+++ b/app/src/main/res/xml/device_admin_policies.xml
@@ -2,6 +2,7 @@
 <device-admin xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-policies>
         <force-lock />
+        <reset-password />
         <wipe-data />
     </uses-policies>
 </device-admin>


### PR DESCRIPTION
Support change_password actions from Firebase admin_actions by carrying password payload fields through the worker and invoking DevicePolicyManager resetPassword in DeviceAdminService. Update admin action completion writes to set action_performed_timestamp when executed is marked true.