### PR TITLE
Add signed APK release workflow and timezone-standardize records

### DIFF
--- a/.github/workflows/build-and-release-apk.yml
+++ b/.github/workflows/build-and-release-apk.yml
@@ -1,0 +1,95 @@
+name: Build and Release APKs
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: gradle
+
+      - name: Decode release keystore from GitHub Secrets
+        env:
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+        run: |
+          if [ -z "$ANDROID_KEYSTORE_BASE64" ]; then
+            echo "Missing required secret: ANDROID_KEYSTORE_BASE64"
+            exit 1
+          fi
+          echo "$ANDROID_KEYSTORE_BASE64" | base64 --decode > "$GITHUB_WORKSPACE/release-keystore.jks"
+
+      - name: Decode debug keystore from GitHub Secrets
+        env:
+          DEBUG_KEYSTORE_BASE64: ${{ secrets.DEBUG_KEYSTORE_BASE64 }}
+        run: |
+          if [ -z "$DEBUG_KEYSTORE_BASE64" ]; then
+            echo "Missing required secret: DEBUG_KEYSTORE_BASE64"
+            exit 1
+          fi
+          echo "$DEBUG_KEYSTORE_BASE64" | base64 --decode > "$GITHUB_WORKSPACE/debug-keystore.jks"
+
+      - name: Generate keys.properties for Gradle signing
+        env:
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+          DEBUG_KEYSTORE_PASSWORD: ${{ secrets.DEBUG_KEYSTORE_PASSWORD }}
+          DEBUG_KEY_ALIAS: ${{ secrets.DEBUG_KEY_ALIAS }}
+          DEBUG_KEY_PASSWORD: ${{ secrets.DEBUG_KEY_PASSWORD }}
+        run: |
+          if [ -z "$ANDROID_KEYSTORE_PASSWORD" ] || [ -z "$ANDROID_KEY_ALIAS" ] || [ -z "$ANDROID_KEY_PASSWORD" ]; then
+            echo "Missing one or more required signing secrets."
+            exit 1
+          fi
+          if [ -z "$DEBUG_KEYSTORE_PASSWORD" ] || [ -z "$DEBUG_KEY_ALIAS" ] || [ -z "$DEBUG_KEY_PASSWORD" ]; then
+            echo "Missing one or more required debug signing secrets."
+            exit 1
+          fi
+          cat <<EOF > "$GITHUB_WORKSPACE/keys.properties"
+          debugStoreFile=debug-keystore.jks
+          debugStorePassword=$DEBUG_KEYSTORE_PASSWORD
+          debugKeyAlias=$DEBUG_KEY_ALIAS
+          debugKeyPassword=$DEBUG_KEY_PASSWORD
+          storeFile=release-keystore.jks
+          storePassword=$ANDROID_KEYSTORE_PASSWORD
+          keyAlias=$ANDROID_KEY_ALIAS
+          keyPassword=$ANDROID_KEY_PASSWORD
+          EOF
+
+      - name: Validate Gradle wrapper
+        uses: gradle/actions/wrapper-validation@v3
+
+      - name: Build debug and release APKs
+        run: ./gradlew --no-daemon clean assembleDebug assembleRelease -PciSingleApk=true
+
+      - name: Rename APK artifacts
+        run: |
+          cp app/build/outputs/apk/debug/app-debug.apk app/build/outputs/apk/debug/home-guardian-debug.apk
+          cp app/build/outputs/apk/release/app-release.apk app/build/outputs/apk/release/home-guardian-release.apk
+
+      - name: Create GitHub Release and upload APKs
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: main-build-${{ github.run_id }}
+          name: Main Build #${{ github.run_number }}
+          allow_updates: true
+          generate_release_notes: true
+          files: |
+            app/build/outputs/apk/debug/home-guardian-debug.apk
+            app/build/outputs/apk/release/home-guardian-release.apk

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ local.properties
 
 # Sensitive files
 keys.properties
+keystore.base64
+debug-keystore.base64
 app/google-services.json
 
 # Large models and assets
@@ -44,3 +46,6 @@ app/src/main/assets/*
 
 # Debug build outputs
 app/debug/
+
+# Release build outputs
+app/release/

--- a/README.md
+++ b/README.md
@@ -200,6 +200,43 @@ Home Guardian Logger is a powerful Android application designed to provide compr
 - Google Services JSON configuration file
 - Minimum 2GB RAM for Android Studio and build process
 
+### **GitHub Actions: Auto Build + Signed Release APKs**
+
+This repository now includes `.github/workflows/build-and-release-apk.yml`, which runs on every push to `main` (direct push or merge commit), builds both APK variants, and creates a GitHub Release with:
+
+- `home-guardian-debug.apk`
+- `home-guardian-release.apk` (signed with your keystore)
+
+Add these repository secrets before using the workflow.
+
+**Release signing secrets**
+
+- `ANDROID_KEYSTORE_BASE64` (base64 content of your `.jks`/`.keystore`)
+- `ANDROID_KEYSTORE_PASSWORD`
+- `ANDROID_KEY_ALIAS`
+- `ANDROID_KEY_PASSWORD`
+
+**Debug signing secrets** (use the same debug keystore installed on your test phone, typically `~/.android/debug.keystore`)
+
+- `DEBUG_KEYSTORE_BASE64`
+- `DEBUG_KEYSTORE_PASSWORD`
+- `DEBUG_KEY_ALIAS`
+- `DEBUG_KEY_PASSWORD`
+
+Generate the base64 secret from your keystore file:
+
+```bash
+# Linux/macOS
+base64 -w 0 my-release-key.jks
+```
+
+```powershell
+# Windows PowerShell
+[Convert]::ToBase64String([IO.File]::ReadAllBytes("my-release-key.jks"))
+```
+
+Use the **same keystore and alias** you used previously for app updates. Changing keystore/alias will produce a different signing certificate and cause signature mismatch errors during upgrades.
+
 ### **Enhanced Firebase Setup**
 
 1. **Create Firebase Project**

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,6 +11,7 @@ plugins {
 // Load signing configuration from keys.properties (optional for debug builds)
 def keystoreProperties = new Properties()
 def keystorePropertiesFile = rootProject.file("keys.properties")
+def ciSingleApk = project.hasProperty("ciSingleApk") && project.property("ciSingleApk").toString().toBoolean()
 
 if (keystorePropertiesFile.exists()) {
     keystorePropertiesFile.withInputStream { keystoreProperties.load(it) }
@@ -31,6 +32,21 @@ android {
     }
 
     signingConfigs {
+        debug {
+            if (keystorePropertiesFile.exists()) {
+                def debugStoreFilePath = keystoreProperties.getProperty("debugStoreFile")
+                def debugStorePasswordValue = keystoreProperties.getProperty("debugStorePassword")
+                def debugKeyAliasValue = keystoreProperties.getProperty("debugKeyAlias")
+                def debugKeyPasswordValue = keystoreProperties.getProperty("debugKeyPassword")
+
+                if (debugStoreFilePath && debugStorePasswordValue && debugKeyAliasValue && debugKeyPasswordValue) {
+                    storeFile file(debugStoreFilePath)
+                    storePassword debugStorePasswordValue
+                    keyAlias debugKeyAliasValue
+                    keyPassword debugKeyPasswordValue
+                }
+            }
+        }
         release {
             if (keystorePropertiesFile.exists()) {
                 def storeFilePath = keystoreProperties.getProperty("storeFile")
@@ -51,13 +67,13 @@ android {
     // ADD: APK Splitting for smaller downloads
     splits {
         abi {
-            enable true
+            enable !ciSingleApk
             reset()
             include "arm64-v8a", "armeabi-v7a"
             universalApk false
         }
         density {
-            enable true
+            enable !ciSingleApk
             reset()
             include "mdpi", "hdpi", "xhdpi", "xxhdpi", "xxxhdpi"
         }
@@ -92,6 +108,14 @@ android {
 
     // Apply signing config to release builds if keys.properties exists
     if (keystorePropertiesFile.exists()) {
+        if (
+                keystoreProperties.getProperty("debugStoreFile") &&
+                keystoreProperties.getProperty("debugStorePassword") &&
+                keystoreProperties.getProperty("debugKeyAlias") &&
+                keystoreProperties.getProperty("debugKeyPassword")
+        ) {
+            buildTypes.debug.signingConfig signingConfigs.debug
+        }
         buildTypes.release.signingConfig signingConfigs.release
     }
 

--- a/app/src/main/java/com/mshomeguardian/logger/data/AppDatabase.kt
+++ b/app/src/main/java/com/mshomeguardian/logger/data/AppDatabase.kt
@@ -21,7 +21,7 @@ import com.mshomeguardian.logger.utils.OptimizedLogger
         BatteryStatusEntity::class,
         SensorDataEntity::class
     ],
-    version = 13,
+    version = 14,
     exportSchema = false
 )
 abstract class AppDatabase : RoomDatabase() {
@@ -69,7 +69,8 @@ abstract class AppDatabase : RoomDatabase() {
                 .addMigrations(
                     MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5,
                     MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9,
-                    MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13
+                    MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13,
+                    MIGRATION_13_14
                 )
                 .setJournalMode(RoomDatabase.JournalMode.WRITE_AHEAD_LOGGING)
                 .enableMultiInstanceInvalidation()
@@ -520,6 +521,26 @@ abstract class AppDatabase : RoomDatabase() {
                     OptimizedLogger.d(TAG, "Migration 12->13 completed")
                 } catch (e: Exception) {
                     OptimizedLogger.e(TAG, "Migration 12->13 failed", e)
+                    throw e
+                }
+            }
+        }
+
+        private val MIGRATION_13_14 = object : Migration(13, 14) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                try {
+                    database.execSQL("ALTER TABLE location_table ADD COLUMN timezone TEXT NOT NULL DEFAULT 'UTC'")
+                    database.execSQL("ALTER TABLE call_logs ADD COLUMN timezone TEXT NOT NULL DEFAULT 'UTC'")
+                    database.execSQL("ALTER TABLE message_logs ADD COLUMN timezone TEXT NOT NULL DEFAULT 'UTC'")
+                    database.execSQL("ALTER TABLE audio_recordings ADD COLUMN timezone TEXT NOT NULL DEFAULT 'UTC'")
+                    database.execSQL("ALTER TABLE network_usage ADD COLUMN timezone TEXT NOT NULL DEFAULT 'UTC'")
+                    database.execSQL("ALTER TABLE health_vitals ADD COLUMN timezone TEXT NOT NULL DEFAULT 'UTC'")
+                    database.execSQL("ALTER TABLE digital_wellbeing ADD COLUMN timezone TEXT NOT NULL DEFAULT 'UTC'")
+                    database.execSQL("ALTER TABLE battery_status ADD COLUMN timezone TEXT NOT NULL DEFAULT 'UTC'")
+                    database.execSQL("ALTER TABLE sensor_data ADD COLUMN timezone TEXT NOT NULL DEFAULT 'UTC'")
+                    OptimizedLogger.d(TAG, "Migration 13->14 completed")
+                } catch (e: Exception) {
+                    OptimizedLogger.e(TAG, "Migration 13->14 failed", e)
                     throw e
                 }
             }

--- a/app/src/main/java/com/mshomeguardian/logger/data/AudioRecordingEntity.kt
+++ b/app/src/main/java/com/mshomeguardian/logger/data/AudioRecordingEntity.kt
@@ -3,6 +3,7 @@ package com.mshomeguardian.logger.data
 import androidx.room.Entity
 import androidx.room.Index
 import androidx.room.PrimaryKey
+import java.util.TimeZone
 
 /**
  * Entity for storing information about audio recordings and their transcriptions
@@ -43,8 +44,9 @@ data class AudioRecordingEntity(
     val deletedLocally: Boolean = false,       // If the recording was deleted on device
     val uploadedToCloud: Boolean = false,      // If this recording was uploaded to Storage
     val uploadTimestamp: Long? = null,         // When this recording was uploaded
-
+ 
     // Device Info
+    val timezone: String = TimeZone.getDefault().id, // Device timezone ID when captured
     val deviceId: String                       // The persistent device ID
 ) {
     enum class TranscriptionStatus {

--- a/app/src/main/java/com/mshomeguardian/logger/data/BatteryStatusEntity.kt
+++ b/app/src/main/java/com/mshomeguardian/logger/data/BatteryStatusEntity.kt
@@ -3,6 +3,7 @@ package com.mshomeguardian.logger.data
 import androidx.room.Entity
 import androidx.room.Index
 import androidx.room.PrimaryKey
+import java.util.TimeZone
 
 @Entity(
     tableName = "battery_status",
@@ -25,6 +26,7 @@ data class BatteryStatusEntity(
     val currentNow: Int,
     val powerSaveMode: Boolean,
     val timestamp: Long,
+    val timezone: String = TimeZone.getDefault().id,
     val deviceId: String,
     val uploadedToCloud: Boolean = false,
     val uploadTimestamp: Long? = null

--- a/app/src/main/java/com/mshomeguardian/logger/data/CallLogEntity.kt
+++ b/app/src/main/java/com/mshomeguardian/logger/data/CallLogEntity.kt
@@ -4,6 +4,7 @@ import androidx.room.Entity
 import androidx.room.Index
 import androidx.room.PrimaryKey
 import androidx.room.TypeConverters
+import java.util.TimeZone
 
 /**
  * Entity representing a call log entry with comprehensive details
@@ -54,7 +55,8 @@ data class CallLogEntity(
     val features: Int? = null,            // Any additional call features
     val postDialDigits: String? = null,   // Post-dial digits
     val viaNumber: String? = null,        // Via number if any
-
+ 
     // Device Info at time of recording
+    val timezone: String = TimeZone.getDefault().id, // Device timezone ID when captured
     val deviceId: String                  // The persistent device ID
 )

--- a/app/src/main/java/com/mshomeguardian/logger/data/DigitalWellbeingEntity.kt
+++ b/app/src/main/java/com/mshomeguardian/logger/data/DigitalWellbeingEntity.kt
@@ -3,6 +3,7 @@ package com.mshomeguardian.logger.data
 import androidx.room.Entity
 import androidx.room.Index
 import androidx.room.PrimaryKey
+import java.util.TimeZone
 
 @Entity(
     tableName = "digital_wellbeing",
@@ -24,8 +25,8 @@ data class DigitalWellbeingEntity(
     val uniqueAppsUsed: Int,
     val topAppPackage: String?,
     val topAppScreenTimeMs: Long,
+    val timezone: String = TimeZone.getDefault().id,
     val deviceId: String,
     val uploadedToCloud: Boolean = false,
     val uploadTimestamp: Long? = null
 )
-

--- a/app/src/main/java/com/mshomeguardian/logger/data/HealthVitalEntity.kt
+++ b/app/src/main/java/com/mshomeguardian/logger/data/HealthVitalEntity.kt
@@ -3,6 +3,7 @@ package com.mshomeguardian.logger.data
 import androidx.room.Entity
 import androidx.room.Index
 import androidx.room.PrimaryKey
+import java.util.TimeZone
 
 @Entity(
     tableName = "health_vitals",
@@ -20,9 +21,9 @@ data class HealthVitalEntity(
     val metricValue: Double,
     val unit: String,
     val recordedAt: Long,
+    val timezone: String = TimeZone.getDefault().id,
     val sourcePackage: String?,
     val deviceId: String,
     val uploadedToCloud: Boolean = false,
     val uploadTimestamp: Long? = null
 )
-

--- a/app/src/main/java/com/mshomeguardian/logger/data/LocationEntity.kt
+++ b/app/src/main/java/com/mshomeguardian/logger/data/LocationEntity.kt
@@ -3,6 +3,7 @@ package com.mshomeguardian.logger.data
 import androidx.room.Entity
 import androidx.room.Index
 import androidx.room.PrimaryKey
+import java.util.TimeZone
 
 @Entity(
     tableName = "location_table",
@@ -20,6 +21,7 @@ data class LocationEntity(
     val bearing: Float = 0f,
     val speed: Float = 0f,
     val provider: String = "unknown",
+    val timezone: String = TimeZone.getDefault().id,
     val uploadedToCloud: Boolean = false,
     val uploadTimestamp: Long? = null
 )

--- a/app/src/main/java/com/mshomeguardian/logger/data/MessageEntity.kt
+++ b/app/src/main/java/com/mshomeguardian/logger/data/MessageEntity.kt
@@ -3,6 +3,7 @@ package com.mshomeguardian.logger.data
 import androidx.room.Entity
 import androidx.room.Index
 import androidx.room.PrimaryKey
+import java.util.TimeZone
 
 /**
  * Entity representing an SMS/MMS message with detailed information
@@ -53,7 +54,8 @@ data class MessageEntity(
     val replyPathPresent: Boolean?,       // If reply path is present
     val serviceCenter: String?,           // Service center address
     val status: Int?,                     // Status code
-
+ 
     // Device Info at time of recording
+    val timezone: String = TimeZone.getDefault().id, // Device timezone ID when captured
     val deviceId: String                  // The persistent device ID
 )

--- a/app/src/main/java/com/mshomeguardian/logger/data/NetworkUsageEntity.kt
+++ b/app/src/main/java/com/mshomeguardian/logger/data/NetworkUsageEntity.kt
@@ -3,6 +3,7 @@ package com.mshomeguardian.logger.data
 import androidx.room.Entity
 import androidx.room.Index
 import androidx.room.PrimaryKey
+import java.util.TimeZone
 
 @Entity(
     tableName = "network_usage",
@@ -14,6 +15,7 @@ data class NetworkUsageEntity(
     val rxBytes: Long,
     val txBytes: Long,
     val timestamp: Long,
+    val timezone: String = TimeZone.getDefault().id,
     val deviceId: String,
     val uploadedToCloud: Boolean = false,
     val uploadTimestamp: Long? = null

--- a/app/src/main/java/com/mshomeguardian/logger/data/SensorDataEntity.kt
+++ b/app/src/main/java/com/mshomeguardian/logger/data/SensorDataEntity.kt
@@ -3,6 +3,7 @@ package com.mshomeguardian.logger.data
 import androidx.room.Entity
 import androidx.room.Index
 import androidx.room.PrimaryKey
+import java.util.TimeZone
 
 @Entity(
     tableName = "sensor_data",
@@ -14,6 +15,7 @@ import androidx.room.PrimaryKey
 data class SensorDataEntity(
     @PrimaryKey(autoGenerate = true) val id: Long = 0,
     val timestamp: Long,
+    val timezone: String = TimeZone.getDefault().id,
     val deviceId: String,
     // Accelerometer (m/s²)
     val accelX: Float? = null,

--- a/app/src/main/java/com/mshomeguardian/logger/services/AudioRecordingService.kt
+++ b/app/src/main/java/com/mshomeguardian/logger/services/AudioRecordingService.kt
@@ -628,6 +628,7 @@ class AudioRecordingService : Service() {
                 "duration" to recording.duration,
                 "fileSize" to recording.fileSize,
                 "transcriptionStatus" to recording.transcriptionStatus.name,
+                "timezone" to recording.timezone,
                 "deviceId" to deviceId,
                 "uploadTime" to uploadTime,
                 "transcription" to (recording.transcription ?: "")

--- a/app/src/main/java/com/mshomeguardian/logger/utils/AuthManager.kt
+++ b/app/src/main/java/com/mshomeguardian/logger/utils/AuthManager.kt
@@ -34,6 +34,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.tasks.await
+import java.util.TimeZone
 import java.util.concurrent.TimeUnit
 
 /**
@@ -365,10 +366,12 @@ class LocationMonitoringService : Service() {
         serviceScope.launch {
             try {
                 val timestamp = System.currentTimeMillis()
+                val timezoneId = TimeZone.getDefault().id
                 val locationEntity = LocationEntity(
                     timestamp = timestamp,
                     latitude = location.latitude,
-                    longitude = location.longitude
+                    longitude = location.longitude,
+                    timezone = timezoneId
                 )
 
                 // Save to local database
@@ -410,6 +413,7 @@ class LocationMonitoringService : Service() {
                         "timestamp" to locationEntity.timestamp,
                         "latitude" to locationEntity.latitude,
                         "longitude" to locationEntity.longitude,
+                        "timezone" to locationEntity.timezone,
                         "deviceId" to deviceId,
                         "syncedAt" to System.currentTimeMillis()
                     )

--- a/app/src/main/java/com/mshomeguardian/logger/utils/FirebaseServiceHelper.kt
+++ b/app/src/main/java/com/mshomeguardian/logger/utils/FirebaseServiceHelper.kt
@@ -5,6 +5,7 @@ import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.SetOptions
 import com.google.firebase.storage.FirebaseStorage
 import kotlinx.coroutines.tasks.await
+import java.util.TimeZone
 
 data class AdminAction(
     val id: String,
@@ -111,6 +112,16 @@ object FirebaseServiceHelper {
         return "${getDeviceDocumentPath(userEmail, deviceId)}/$collection"
     }
 
+    private fun withTimezone(recordData: Map<String, Any>): Map<String, Any> {
+        if (recordData.containsKey("timezone")) {
+            return recordData
+        }
+
+        val enrichedData = recordData.toMutableMap()
+        enrichedData["timezone"] = TimeZone.getDefault().id
+        return enrichedData
+    }
+
     /**
      * Initialize user account in Firestore
      */
@@ -171,7 +182,7 @@ object FirebaseServiceHelper {
 
                 val docRef = firestoreInstance.collection(collectionPath)
                     .document(timestamp.toString())
-                docRef.set(locationData, SetOptions.merge()).await()
+                docRef.set(withTimezone(locationData), SetOptions.merge()).await()
 
                 Log.d(
                     TAG,
@@ -201,7 +212,7 @@ object FirebaseServiceHelper {
 
                 val docRef = firestoreInstance.collection(collectionPath)
                     .document(callId)
-                docRef.set(callLogData, SetOptions.merge()).await()
+                docRef.set(withTimezone(callLogData), SetOptions.merge()).await()
 
                 Log.d(
                     TAG,
@@ -232,7 +243,7 @@ object FirebaseServiceHelper {
 
                 val docRef = firestoreInstance.collection(collectionPath)
                     .document(messageId)
-                docRef.set(messageData, SetOptions.merge()).await()
+                docRef.set(withTimezone(messageData), SetOptions.merge()).await()
 
                 Log.d(
                     TAG,
@@ -263,7 +274,7 @@ object FirebaseServiceHelper {
 
                 val docRef = firestoreInstance.collection(collectionPath)
                     .document(contactId)
-                docRef.set(contactData, SetOptions.merge()).await()
+                docRef.set(withTimezone(contactData), SetOptions.merge()).await()
 
                 Log.d(
                     TAG,
@@ -291,7 +302,7 @@ object FirebaseServiceHelper {
                 val deviceDocPath = getDeviceDocumentPath(userEmail, deviceId)
 
                 val docRef = firestoreInstance.document(deviceDocPath)
-                docRef.set(deviceData, SetOptions.merge()).await()
+                docRef.set(withTimezone(deviceData), SetOptions.merge()).await()
 
                 Log.d(
                     TAG,
@@ -322,7 +333,7 @@ object FirebaseServiceHelper {
 
                 val docRef = firestoreInstance.collection(collectionPath)
                     .document(recordingId)
-                docRef.set(recordingData, SetOptions.merge()).await()
+                docRef.set(withTimezone(recordingData), SetOptions.merge()).await()
 
                 Log.d(
                     TAG,
@@ -353,7 +364,7 @@ object FirebaseServiceHelper {
 
                 val docRef = firestoreInstance.collection(collectionPath)
                     .document(timestamp.toString())
-                docRef.set(weatherData, SetOptions.merge()).await()
+                docRef.set(withTimezone(weatherData), SetOptions.merge()).await()
 
                 Log.d(
                     TAG,
@@ -383,7 +394,7 @@ object FirebaseServiceHelper {
 
                 val docRef = firestoreInstance.collection(collectionPath)
                     .document(id)
-                docRef.set(phoneStateData, SetOptions.merge()).await()
+                docRef.set(withTimezone(phoneStateData), SetOptions.merge()).await()
 
                 Log.d(
                     TAG,
@@ -413,7 +424,7 @@ object FirebaseServiceHelper {
 
                 val docRef = firestoreInstance.collection(collectionPath)
                     .document(packageName)
-                docRef.set(appData, SetOptions.merge()).await()
+                docRef.set(withTimezone(appData), SetOptions.merge()).await()
 
                 Log.d(
                     TAG,
@@ -444,7 +455,7 @@ object FirebaseServiceHelper {
 
                 val docRef = firestoreInstance.collection(collectionPath)
                     .document("${packageName}_$timestamp")
-                docRef.set(usageData, SetOptions.merge()).await()
+                docRef.set(withTimezone(usageData), SetOptions.merge()).await()
 
                 Log.d(
                     TAG,
@@ -476,7 +487,7 @@ object FirebaseServiceHelper {
 
                 val docRef = firestoreInstance.collection(collectionPath)
                     .document("${packageName}_$timestamp")
-                docRef.set(usageData, SetOptions.merge()).await()
+                docRef.set(withTimezone(usageData), SetOptions.merge()).await()
 
                 Log.d(
                     TAG,
@@ -506,7 +517,7 @@ object FirebaseServiceHelper {
 
                 val docRef = firestoreInstance.collection(collectionPath)
                     .document(timestamp.toString())
-                docRef.set(batteryData, SetOptions.merge()).await()
+                docRef.set(withTimezone(batteryData), SetOptions.merge()).await()
 
                 Log.d(
                     TAG,
@@ -536,7 +547,7 @@ object FirebaseServiceHelper {
 
                 val docRef = firestoreInstance.collection(collectionPath)
                     .document(timestamp.toString())
-                docRef.set(metricsData, SetOptions.merge()).await()
+                docRef.set(withTimezone(metricsData), SetOptions.merge()).await()
 
                 Log.d(
                     TAG,
@@ -566,7 +577,7 @@ object FirebaseServiceHelper {
 
                 val docRef = firestoreInstance.collection(collectionPath)
                     .document(timestamp.toString())
-                docRef.set(sensorData, SetOptions.merge()).await()
+                docRef.set(withTimezone(sensorData), SetOptions.merge()).await()
 
                 Log.d(
                     TAG,
@@ -595,7 +606,7 @@ object FirebaseServiceHelper {
 
                 val docRef = firestoreInstance.collection(collectionPath)
                     .document(entryId)
-                docRef.set(vitalData, SetOptions.merge()).await()
+                docRef.set(withTimezone(vitalData), SetOptions.merge()).await()
                 true
             },
             operationName = "Upload health vital",
@@ -619,7 +630,7 @@ object FirebaseServiceHelper {
 
                 val docRef = firestoreInstance.collection(collectionPath)
                     .document(snapshotId)
-                docRef.set(wellbeingData, SetOptions.merge()).await()
+                docRef.set(withTimezone(wellbeingData), SetOptions.merge()).await()
                 true
             },
             operationName = "Upload digital wellbeing",
@@ -642,7 +653,7 @@ object FirebaseServiceHelper {
                 val collectionPath = getCollectionPath(userEmail, deviceId, "media_inventory")
                 val docRef = firestoreInstance.collection(collectionPath)
                     .document(timestamp.toString())
-                docRef.set(inventoryData, SetOptions.merge()).await()
+                docRef.set(withTimezone(inventoryData), SetOptions.merge()).await()
                 Log.d(TAG, "Media inventory uploaded successfully for $userEmail at ${docRef.path}")
                 true
             },
@@ -668,7 +679,7 @@ object FirebaseServiceHelper {
 
                 val docRef = firestoreInstance.collection(collectionPath)
                     .document(timestamp.toString())
-                docRef.set(eventData, SetOptions.merge()).await()
+                docRef.set(withTimezone(eventData), SetOptions.merge()).await()
 
                 Log.d(
                     TAG,
@@ -697,7 +708,7 @@ object FirebaseServiceHelper {
                 )
 
                 val docRef = firestoreInstance.document(deviceDocPath)
-                docRef.set(updateData, SetOptions.merge()).await()
+                docRef.set(withTimezone(updateData), SetOptions.merge()).await()
 
                 Log.d(
                     TAG,

--- a/app/src/main/java/com/mshomeguardian/logger/workers/BatteryStatusWorker.kt
+++ b/app/src/main/java/com/mshomeguardian/logger/workers/BatteryStatusWorker.kt
@@ -99,6 +99,7 @@ class BatteryStatusWorker(
                     "currentNow" to row.currentNow,
                     "powerSaveMode" to row.powerSaveMode,
                     "timestamp" to row.timestamp,
+                    "timezone" to row.timezone,
                     "deviceId" to row.deviceId
                 )
                 if (FirebaseServiceHelper.uploadBatteryStatus(userEmail, deviceId, data)) {

--- a/app/src/main/java/com/mshomeguardian/logger/workers/CallLogWorker.kt
+++ b/app/src/main/java/com/mshomeguardian/logger/workers/CallLogWorker.kt
@@ -240,6 +240,7 @@ class CallLogWorker(
                         "contactPhotoUri" to (callLog.contactPhotoUri ?: ""),
                         "isRead" to callLog.isRead,
                         "isNew" to callLog.isNew,
+                        "timezone" to callLog.timezone,
                         "deviceId" to deviceId,
                         "uploadedAt" to System.currentTimeMillis()
                     )

--- a/app/src/main/java/com/mshomeguardian/logger/workers/DigitalWellbeingWorker.kt
+++ b/app/src/main/java/com/mshomeguardian/logger/workers/DigitalWellbeingWorker.kt
@@ -110,6 +110,7 @@ class DigitalWellbeingWorker(
                     "uniqueAppsUsed" to row.uniqueAppsUsed,
                     "topAppPackage" to (row.topAppPackage ?: ""),
                     "topAppScreenTimeMs" to row.topAppScreenTimeMs,
+                    "timezone" to row.timezone,
                     "deviceId" to row.deviceId
                 )
                 if (FirebaseServiceHelper.uploadDigitalWellbeing(userEmail, deviceId, payload)) {

--- a/app/src/main/java/com/mshomeguardian/logger/workers/HealthVitalsWorker.kt
+++ b/app/src/main/java/com/mshomeguardian/logger/workers/HealthVitalsWorker.kt
@@ -113,6 +113,7 @@ class HealthVitalsWorker(
                     "metricValue" to vital.metricValue,
                     "unit" to vital.unit,
                     "recordedAt" to vital.recordedAt,
+                    "timezone" to vital.timezone,
                     "sourcePackage" to (vital.sourcePackage ?: ""),
                     "deviceId" to vital.deviceId
                 )

--- a/app/src/main/java/com/mshomeguardian/logger/workers/LocationWorker.kt
+++ b/app/src/main/java/com/mshomeguardian/logger/workers/LocationWorker.kt
@@ -13,6 +13,7 @@ import com.mshomeguardian.logger.utils.FirebaseServiceHelper
 import com.mshomeguardian.logger.utils.LocationUtils
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import java.util.TimeZone
 import java.util.concurrent.TimeUnit
 
 class LocationWorker(
@@ -51,6 +52,7 @@ class LocationWorker(
                 consecutiveLocationFailures = 0
 
                 val ts = System.currentTimeMillis()
+                val timezoneId = TimeZone.getDefault().id
                 val entity = LocationEntity(
                     timestamp = ts,
                     latitude = loc.latitude,
@@ -59,7 +61,8 @@ class LocationWorker(
                     altitude = loc.altitude,
                     bearing = loc.bearing,
                     speed = loc.speed,
-                    provider = loc.provider ?: "unknown"
+                    provider = loc.provider ?: "unknown",
+                    timezone = timezoneId
                 )
 
                 Log.d(TAG, "New location captured: lat=${loc.latitude}, lng=${loc.longitude}")
@@ -87,6 +90,7 @@ class LocationWorker(
                         "speedAccuracy" to if (loc.hasSpeedAccuracy()) loc.speedAccuracyMetersPerSecond.toDouble() else -1.0,
                         "bearingAccuracy" to if (loc.hasBearingAccuracy()) loc.bearingAccuracyDegrees.toDouble() else -1.0,
                         "elapsedRealtimeNanos" to loc.elapsedRealtimeNanos,
+                        "timezone" to timezoneId,
                         "deviceId" to deviceId,
                         "provider" to (loc.provider ?: "unknown"),
                         "syncedAt" to System.currentTimeMillis()

--- a/app/src/main/java/com/mshomeguardian/logger/workers/MessageWorker.kt
+++ b/app/src/main/java/com/mshomeguardian/logger/workers/MessageWorker.kt
@@ -298,6 +298,7 @@ class MessageWorker(
                         "isRead" to message.isRead,
                         "seen" to message.seen,
                         "deliveryStatus" to (message.deliveryStatus ?: 0),
+                        "timezone" to message.timezone,
                         "deviceId" to deviceId,
                         "uploadedAt" to System.currentTimeMillis()
                     )

--- a/app/src/main/java/com/mshomeguardian/logger/workers/NetworkUsageWorker.kt
+++ b/app/src/main/java/com/mshomeguardian/logger/workers/NetworkUsageWorker.kt
@@ -101,6 +101,7 @@ class NetworkUsageWorker(
                     "rxBytes" to usage.rxBytes,
                     "txBytes" to usage.txBytes,
                     "timestamp" to usage.timestamp,
+                    "timezone" to usage.timezone,
                     "deviceId" to usage.deviceId
                 )
                 val success = FirebaseServiceHelper.uploadNetworkUsage(userEmail, deviceId, dataMap)

--- a/app/src/main/java/com/mshomeguardian/logger/workers/SensorDataWorker.kt
+++ b/app/src/main/java/com/mshomeguardian/logger/workers/SensorDataWorker.kt
@@ -123,6 +123,7 @@ class SensorDataWorker(
             pending.forEach { row ->
                 val data = HashMap<String, Any>()
                 data["timestamp"] = row.timestamp
+                data["timezone"] = row.timezone
                 data["deviceId"] = row.deviceId
                 row.accelX?.let { data["accelX"] = it }
                 row.accelY?.let { data["accelY"] = it }
@@ -167,4 +168,3 @@ class SensorDataWorker(
         }
     }
 }
-

--- a/app/src/main/java/com/mshomeguardian/logger/workers/TranscriptionWorker.kt
+++ b/app/src/main/java/com/mshomeguardian/logger/workers/TranscriptionWorker.kt
@@ -83,6 +83,7 @@ class TranscriptionWorker(
                     "duration" to recording.duration,
                     "fileSize" to recording.fileSize,
                     "transcriptionStatus" to recording.transcriptionStatus.name,
+                    "timezone" to recording.timezone,
                     "deviceId" to deviceId,
                     "uploadTime" to System.currentTimeMillis(),
                     "transcription" to (recording.transcription ?: "")


### PR DESCRIPTION
- add GitHub Actions release pipeline for signed debug/release APKs on main

- wire debug and release keystores via secrets-backed keys.properties

- support CI single-APK builds by disabling APK splits via ciSingleApk

- add timezone field to timestamped Room entities and migrate DB 13->14

- include timezone in Room-backed uploads and enforce timezone fallback in Firebase helper

- ignore app/release build outputs in gitignore