### PR TITLE
Fix CI build by restoring google-services.json from secret

### DIFF
--- a/.github/workflows/build-and-release-apk.yml
+++ b/.github/workflows/build-and-release-apk.yml
@@ -24,6 +24,16 @@ jobs:
           java-version: '17'
           cache: gradle
 
+      - name: Decode google-services.json from GitHub Secrets
+        env:
+          GOOGLE_SERVICES_JSON_BASE64: ${{ secrets.GOOGLE_SERVICES_JSON_BASE64 }}
+        run: |
+          if [ -z "$GOOGLE_SERVICES_JSON_BASE64" ]; then
+            echo "Missing required secret: GOOGLE_SERVICES_JSON_BASE64"
+            exit 1
+          fi
+          echo "$GOOGLE_SERVICES_JSON_BASE64" | base64 --decode > "$GITHUB_WORKSPACE/app/google-services.json"
+
       - name: Decode release keystore from GitHub Secrets
         env:
           ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}

--- a/README.md
+++ b/README.md
@@ -209,6 +209,10 @@ This repository now includes `.github/workflows/build-and-release-apk.yml`, whic
 
 Add these repository secrets before using the workflow.
 
+**Firebase config secret**
+
+- `GOOGLE_SERVICES_JSON_BASE64` (base64 content of `app/google-services.json`)
+
 **Release signing secrets**
 
 - `ANDROID_KEYSTORE_BASE64` (base64 content of your `.jks`/`.keystore`)
@@ -233,6 +237,11 @@ base64 -w 0 my-release-key.jks
 ```powershell
 # Windows PowerShell
 [Convert]::ToBase64String([IO.File]::ReadAllBytes("my-release-key.jks"))
+```
+
+```powershell
+# Windows PowerShell (google-services.json)
+[Convert]::ToBase64String([IO.File]::ReadAllBytes("google-services.json"))
 ```
 
 Use the **same keystore and alias** you used previously for app updates. Changing keystore/alias will produce a different signing certificate and cause signature mismatch errors during upgrades.


### PR DESCRIPTION
- decode GOOGLE_SERVICES_JSON_BASE64 into app/google-services.json in GitHub Actions

- document the new Firebase config secret setup in README